### PR TITLE
Pull request - lots of changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,13 @@
 bootstrap-select
 ================
 
-A custom select for @twitter bootstrap using button dropdown; 
+A custom select for @twitter bootstrap using button dropdown, designed to behave like regular Bootstrap selects; 
 originally by [Silvio Moreto](http://github.com/silviomoreto) and [Ana Carolina](http://github.com/anacarolinats).
- See a here an [example](http://silviomoreto.github.com/bootstrap-select/)
-
-## Observation
-
-To properly work on some browser, you need to add a `.clearfix` class in your css.
+ See a here an [example](http://caseyjhol.github.com/bootstrap-select/)
 
 # Usage
 
-Create yours `<select>` and add to them the class `.selectpicker`, like example below:
+Create your `<select>` with the `.selectpicker` class.
 
     <select class="selectpicker">
       <option>Mustard</select>
@@ -19,7 +15,7 @@ Create yours `<select>` and add to them the class `.selectpicker`, like example 
       <option>Barbecue</select>
     </select>
     
-In your javascript, just add the line:
+Enable Bootstrap-Select via JavaScript:
 
     $('.selectpicker').selectpicker();
 
@@ -27,11 +23,11 @@ Or just
 
     $('select').selectpicker();
     
-You can also pass a button bootstrap class to your select using the option `btnStyle` or the drop `direction`, like:
+Options can be passed via data attributes or JavaScript.
 
     $('.selectpicker').selectpicker({
-      btnStyle: 'btn-info',
-      direction: 'dropup'
+      style: 'btn-info',
+      size: 4
     });
 
-bootstrap-select will import the classes from your `<select>`. So you can apply the `span#` classes from Bootstrap and the bootstrap-select can be responsive
+You can set different Bootstrap classes on the button via the `data-style` attribute. Classes are applied to `.btn-group`.Apply `.span*` class to the selects to set the width. Add the `disabled` attribute to the select to apply the `.disabled` class. Specify `data-size` to choose how many items to show in the menu by default. Make the select a dropup menu by adding the `.dropup` class to the select.

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ bootstrap-select
 
 A custom select for @twitter bootstrap using button dropdown, designed to behave like regular Bootstrap selects; 
 originally by [Silvio Moreto](http://github.com/silviomoreto) and [Ana Carolina](http://github.com/anacarolinats).
- See a here an [example](http://caseyjhol.github.com/bootstrap-select/)
-
+ See an [example](http://caseyjhol.github.com/bootstrap-select/).
 # Usage
 
 Create your `<select>` with the `.selectpicker` class.

--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -1,15 +1,34 @@
 .clearfix:after {
-    visibility: hidden;
-    display: block;
-    font-size: 0;
-    content: " ";
-    clear: both;
-    height: 0;
- }
- .bootstrap-select.btn-group {
-    float:none; 
- 	display: inline-block;
- 	margin-bottom: 10px;
- 	margin-left:0;
- 	width: 220px;
- }
+	visibility: hidden;
+	display: block;
+	font-size: 0;
+	content: " ";
+	clear: both;
+	height: 0;
+}
+.bootstrap-select.btn-group, .bootstrap-select.btn-group[class*="span"] {
+	float:none; 
+	display: inline-block;
+	margin-bottom: 10px;
+	margin-left:0;
+}
+.bootstrap-select {
+	width: 220px;
+}
+.bootstrap-select .btn {
+	width: 220px;
+}
+.bootstrap-select.btn-group .btn {
+	cursor: not-allowed;
+}
+.bootstrap-select.btn-group[class*="span"] .btn {
+	width:100%;
+}
+.bootstrap-select.btn-group .dropdown-menu {
+	min-width:100%;
+}
+
+.bootstrap-select.btn-group .dropdown-menu ul {
+	margin:0;
+	list-style:none;
+}

--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -6,9 +6,10 @@
     clear: both;
     height: 0;
  }
-.bootstrap-select.disabled a{
-    opacity: 0.7;
-}
-.bootstrap-select.disabled a span.caret{
-    opacity: 0.7;
-}
+ .bootstrap-select.btn-group {
+    float:none; 
+ 	display: inline-block;
+ 	margin-bottom: 10px;
+ 	margin-left:0;
+ 	width: 220px;
+ }

--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -18,7 +18,11 @@
 .bootstrap-select .btn {
 	width: 220px;
 }
-.bootstrap-select.btn-group .btn {
+.bootstrap-select.btn-group .btn .filter-option {
+	white-space:nowrap;
+	overflow:hidden;
+}
+.bootstrap-select.btn-group .disabled {
 	cursor: not-allowed;
 }
 .bootstrap-select.btn-group[class*="span"] .btn {
@@ -26,6 +30,9 @@
 }
 .bootstrap-select.btn-group .dropdown-menu {
 	min-width:100%;
+	-moz-box-sizing:border-box;
+	-webkit-box-sizing:border-box;
+	box-sizing:border-box;
 }
 
 .bootstrap-select.btn-group .dropdown-menu ul {

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -21,6 +21,7 @@
             var btnclassList = this.$element.attr('data-btnstyle');
             var template = this.getTemplate();
             var id = this.$element.attr('id');
+            var size = this.$element.attr('data-size');
             template = this.createLi(template);
             this.$element.after(template);
             this.$newElement = this.$element.next('.bootstrap-select');
@@ -38,6 +39,11 @@
             } else {
                 this.$newElement.find('> button').addClass(this.selectClass);
             }
+            if (size !== undefined && this.$newElement.find('.dropdown-menu ul li').length > size) {
+                var menuA = this.$newElement.find('.dropdown-menu ul li > a');
+                var height = (parseInt(menuA.css('line-height')) + parseInt(menuA.css('padding-top')) + parseInt(menuA.css('padding-bottom')))*size;
+                this.$newElement.find('.dropdown-menu ul').css({'max-height' : height + 'px', 'overflow-y' : 'scroll'});
+            }
             this.checkDisabled();
             this.clickListener();
 
@@ -52,9 +58,11 @@
                         "<span class='filter-option pull-left'>__SELECTED_OPTION&nbsp;</span> " +
                         "<span class='caret pull-right'></span>" +
                     "</button>" +
-                    "<ul class='dropdown-menu' role='menu'>" +
-                        "__ADD_LI" +
-                    "</ul>" +
+                    "<div class='dropdown-menu' role='menu'>" +
+                        "<ul>" +
+                            "__ADD_LI" +
+                        "</ul>" +
+                    "</div>" +
                 "</div>";
 
             return template;
@@ -74,12 +82,11 @@
             if(_li.length > 0) {
                 template = template.replace('__SELECTED_OPTION', _li[_selected_index]);
                 for (var i = 0; i < _li.length; i++) {
-                    _liHtml += "<li rel=" + i + "><a tabindex='-1' href='#'>" + _li[i] + "</a></li>";
+                    _liHtml += "<li rel=" + i + "><a tabindex='-1' href='#'>" + _li[i] + "&nbsp;</a></li>";
                 }
             }
 
-
-            this.$element.find('option')[_selected_index].setAttribute('selected', 'selected');
+            this.$element.find('option').eq(_selected_index).prop('selected',true);
 
             template = template.replace('__ADD_LI', _liHtml);
 
@@ -97,17 +104,13 @@
             $('body').on('touchstart.dropdown', '.dropdown-menu', function (e) { e.stopPropagation(); });
             this.$newElement.find('li').on('click', function(e) {
                 e.preventDefault();
-
+                var selected = $(this).index();
                 var $this = $(this),
                     rel = $this.attr('rel'),
                     $select = $this.parents('.bootstrap-select');
 
                 if (_this.$element.not(':disabled')){
-                    $select.prev('select').find('option').removeAttr('selected');
-
-                    $select.prev('select').find('option')[parseInt(rel,10)]
-                        .setAttribute('selected', 'selected');
-
+                    $select.prev('select').find('option').eq(selected).prop('selected',true);
                     $select.find('.filter-option').html($this.text());
 
                     // Trigger select 'change'

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -16,8 +16,8 @@
         contructor: Selectpicker,
 
         init: function (e) {
-            this.$element.css('display', 'none');
             var classList = this.$element.attr('class') !== undefined ? this.$element.attr('class').split(/\s+/) : '';
+            var btnclassList = this.$element.attr('data-btnstyle');
             var template = this.getTemplate();
             var id = this.$element.attr('id');
             template = this.createLi(template);
@@ -32,19 +32,24 @@
                     this.$newElement.addClass(classList[i]);
                 }
             };
-            this.$newElement.find('> button').addClass(this.selectClass + ' span12');
+            if (btnclassList !== undefined) {
+                this.$newElement.find('> button').addClass(btnclassList);
+            } else {
+                this.$newElement.find('> button').addClass(this.selectClass);
+            }
             this.checkDisabled();
             this.clickListener();
 
             this.$newElement.find('ul').bind('DOMNodeInserted',
                 $.proxy(this.clickListener, this));
+            this.$element.remove();
         },
 
         getTemplate: function() {
             var template =
                 "<div class='btn-group bootstrap-select'>" +
                     "<button class='btn dropdown-toggle clearfix' data-toggle='dropdown'>" +
-                        "<span class='filter-option pull-left'>__SELECTED_OPTION &nbsp;</span> " +
+                        "<span class='filter-option pull-left'>__SELECTED_OPTION&nbsp;</span> " +
                         "<span class='caret pull-right'></span>" +
                     "</button>" +
                     "<ul class='dropdown-menu' role='menu'>" +

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -6,42 +6,39 @@
         }
         this.$element = $(element);
         this.$newElement = null;
-        this.selectClass = options.btnStyle || '';
-        this.direction = options.direction || '';
+        this.options = $.extend({}, $.fn.selectpicker.defaults, options);
+        this.style = this.options.style || this.$element.attr('data-style');
+        this.size = this.options.size || this.$element.attr('data-size');
         this.init();
     };
 
     Selectpicker.prototype = {
 
-        contructor: Selectpicker,
+        constructor: Selectpicker,
 
         init: function (e) {
             this.$element.hide();
             var classList = this.$element.attr('class') !== undefined ? this.$element.attr('class').split(/\s+/) : '';
-            var btnclassList = this.$element.attr('data-btnstyle');
             var template = this.getTemplate();
             var id = this.$element.attr('id');
-            var size = this.$element.attr('data-size');
             template = this.createLi(template);
             this.$element.after(template);
             this.$newElement = this.$element.next('.bootstrap-select');
-            this.$newElement.addClass(this.direction);
+            var button = this.$newElement.find('> button');
             if (id !== undefined) {
-                this.$newElement.find('> button').attr('id', id);
+                button.attr('id', id);
             }
             for (var i = 0; i < classList.length; i++) {
                 if(classList[i] != 'selectpicker') {
                     this.$newElement.addClass(classList[i]);
                 }
-            };
-            if (btnclassList !== undefined) {
-                this.$newElement.find('> button').addClass(btnclassList);
-            } else {
-                this.$newElement.find('> button').addClass(this.selectClass);
             }
-            if (size !== undefined && this.$newElement.find('.dropdown-menu ul li').length > size) {
+            var maxWidth = button.outerWidth() - 38;
+            this.$newElement.find('> button > .filter-option').css('max-width',maxWidth + 'px');
+            button.addClass(this.style);
+            if (this.size && this.$newElement.find('.dropdown-menu ul li').length > this.size) {
                 var menuA = this.$newElement.find('.dropdown-menu ul li > a');
-                var height = (parseInt(menuA.css('line-height')) + parseInt(menuA.css('padding-top')) + parseInt(menuA.css('padding-bottom')))*size;
+                var height = (parseInt(menuA.css('line-height')) + menuA.outerHeight())*this.size;
                 this.$newElement.find('.dropdown-menu ul').css({'max-height' : height + 'px', 'overflow-y' : 'scroll'});
             }
             this.checkDisabled();
@@ -55,7 +52,7 @@
             var template =
                 "<div class='btn-group bootstrap-select'>" +
                     "<button class='btn dropdown-toggle clearfix' data-toggle='dropdown'>" +
-                        "<span class='filter-option pull-left'>__SELECTED_OPTION&nbsp;</span> " +
+                        "<span class='filter-option pull-left'>__SELECTED_OPTION</span> " +
                         "<span class='caret pull-right'></span>" +
                     "</button>" +
                     "<div class='dropdown-menu' role='menu'>" +
@@ -82,7 +79,7 @@
             if(_li.length > 0) {
                 template = template.replace('__SELECTED_OPTION', _li[_selected_index]);
                 for (var i = 0; i < _li.length; i++) {
-                    _liHtml += "<li rel=" + i + "><a tabindex='-1' href='#'>" + _li[i] + "&nbsp;</a></li>";
+                    _liHtml += "<li rel=" + i + "><a tabindex='-1' href='#'>" + _li[i] + "</a></li>";
                 }
             }
 
@@ -95,7 +92,11 @@
 
         checkDisabled: function() {
             if (this.$element.is(':disabled')) {
-                this.$newElement.find('> button').addClass('disabled');
+                var button = this.$newElement.find('> button');
+                button.addClass('disabled');
+                button.click(function(e) {
+                    e.preventDefault();
+                });
             }
         },
 
@@ -118,6 +119,11 @@
                 }
 
             });
+            this.$element.on('change', function(e) {
+                var selected = $(this).find('option:selected').text();
+                $(this).next('.bootstrap-select').find('.filter-option').html(selected);
+
+            });
         }
 
     };
@@ -135,5 +141,10 @@
             }
         });
     };
+    
+    $.fn.selectpicker.defaults = {
+        style: null, 
+        size: null
+    }
 
 }(window.jQuery);

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -25,14 +25,14 @@
             this.$newElement = this.$element.next('.bootstrap-select');
             this.$newElement.addClass(this.direction);
             if (id !== undefined) {
-                this.$newElement.find('> a').attr('id', id);
+                this.$newElement.find('> button').attr('id', id);
             }
             for (var i = 0; i < classList.length; i++) {
                 if(classList[i] != 'selectpicker') {
-                    this.$newElement.find('> a').addClass(classList[i]);
+                    this.$newElement.find('> button').addClass(classList[i]);
                 }
             };
-            this.$newElement.find('> a').addClass(this.selectClass);
+            this.$newElement.find('> button').addClass(this.selectClass);
             this.checkDisabled();
             this.clickListener();
 
@@ -43,10 +43,10 @@
         getTemplate: function() {
             var template =
                 "<div class='btn-group bootstrap-select'>" +
-                    "<a class='btn dropdown-toggle clearfix' data-toggle='dropdown' href='#''>" +
+                    "<button class='btn dropdown-toggle clearfix' data-toggle='dropdown'>" +
                         "<span class='filter-option'>__SELECTED_OPTION</span> " +
                         "<span class='caret'></span>" +
-                    "</a>" +
+                    "</button>" +
                     "<ul class='dropdown-menu' role='menu'>" +
                         "__ADD_LI" +
                     "</ul>" +
@@ -83,7 +83,7 @@
 
         checkDisabled: function() {
             if (this.$element.is(':disabled')) {
-                this.$newElement.addClass('disabled');
+                this.$newElement.find('> button').addClass('disabled');
             }
         },
 

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -16,6 +16,7 @@
         contructor: Selectpicker,
 
         init: function (e) {
+            this.$element.hide();
             var classList = this.$element.attr('class') !== undefined ? this.$element.attr('class').split(/\s+/) : '';
             var btnclassList = this.$element.attr('data-btnstyle');
             var template = this.getTemplate();
@@ -42,7 +43,6 @@
 
             this.$newElement.find('ul').bind('DOMNodeInserted',
                 $.proxy(this.clickListener, this));
-            this.$element.remove();
         },
 
         getTemplate: function() {

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -44,8 +44,8 @@
             var template =
                 "<div class='btn-group bootstrap-select'>" +
                     "<a class='btn dropdown-toggle clearfix' data-toggle='dropdown' href='#''>" +
-                        "<span class='filter-option pull-left'>__SELECTED_OPTION</span>" +
-                        "<span class='caret pull-right'></span>" +
+                        "<span class='filter-option'>__SELECTED_OPTION</span> " +
+                        "<span class='caret'></span>" +
                     "</a>" +
                     "<ul class='dropdown-menu' role='menu'>" +
                         "__ADD_LI" +

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -29,10 +29,10 @@
             }
             for (var i = 0; i < classList.length; i++) {
                 if(classList[i] != 'selectpicker') {
-                    this.$newElement.find('> button').addClass(classList[i]);
+                    this.$newElement.addClass(classList[i]);
                 }
             };
-            this.$newElement.find('> button').addClass(this.selectClass);
+            this.$newElement.find('> button').addClass(this.selectClass + ' span12');
             this.checkDisabled();
             this.clickListener();
 
@@ -44,8 +44,8 @@
             var template =
                 "<div class='btn-group bootstrap-select'>" +
                     "<button class='btn dropdown-toggle clearfix' data-toggle='dropdown'>" +
-                        "<span class='filter-option'>__SELECTED_OPTION</span> " +
-                        "<span class='caret'></span>" +
+                        "<span class='filter-option pull-left'>__SELECTED_OPTION &nbsp;</span> " +
+                        "<span class='caret pull-right'></span>" +
                     "</button>" +
                     "<ul class='dropdown-menu' role='menu'>" +
                         "__ADD_LI" +


### PR DESCRIPTION
This started out as me making a few minor changes, but turned into a bigger project than I'd originally intended. See an [example](http://caseyjhol.github.com/bootstrap-select/) with all of my changes. Here's the rundown to my knowledge:

I changed the wrap tag to `<button class='btn dropdown-toggle clearfix' data-toggle='dropdown'>` instead of `<a class='btn dropdown-toggle clearfix' data-toggle='dropdown' href='#''>`. This is a little bit cleaner - also there was an extraneous `'` in the tag. 

Any classes added to the `select`, such as   `.span*`, are now added to `.btn-group` and the width of of `.btn` is set to 100%. This gives proper Bootstrap appearance (as of now `.span*` is added to the button, giving the button a percentage width of its container, `.btn-group`, often causing an undesired look. Other classes can still be added to the button by setting `style` in the options or via the new `data-style` attribute. When the select is disabled, the `.disabled` class is now added to `.btn` itself, rather than `.btn-group`. I set the default width of `.btn-group` so it matches the default Bootstrap `select` width. 

I also added a new `data-size` attribute, which allows you to choose how many items to show in the menu by default. The `ul` menu is now wrapped in a `div` for this feature to work.

I fixed issue #16 and changed the way the options are selected in the process (now using `.prop('selected', true)` instead of `setAttribute`). This is ultimately fewer lines of code and seems to work better for me (I was having issues in Chrome). There's a lot here - perhaps too much for a pull-request, but this now does nearly everything I need it to.
