### PR TITLE
Fix .filter-option width

### DIFF
--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -17,14 +17,17 @@
 }
 .bootstrap-select .btn {
 	width: 220px;
-	padding-right:25px;
 }
 .bootstrap-select.btn-group .btn .filter-option {
-	white-space:nowrap;
-	overflow:hidden;
-	width:100%;
-	text-align:left; 
-	margin-right:5px;
+	overflow:hidden; 
+	position:absolute;
+	left:12px; 
+	right:25px;
+	text-align:left;
+}
+.bootstrap-select.btn-group .btn .caret {
+	position:absolute;
+	right:12px;
 }
 .bootstrap-select.btn-group .disabled {
 	cursor: not-allowed;

--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -17,10 +17,14 @@
 }
 .bootstrap-select .btn {
 	width: 220px;
+	padding-right:25px;
 }
 .bootstrap-select.btn-group .btn .filter-option {
 	white-space:nowrap;
 	overflow:hidden;
+	width:100%;
+	text-align:left; 
+	margin-right:5px;
 }
 .bootstrap-select.btn-group .disabled {
 	cursor: not-allowed;

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -33,8 +33,6 @@
                     this.$newElement.addClass(classList[i]);
                 }
             }
-            var maxWidth = button.outerWidth() - 38;
-            this.$newElement.find('> button > .filter-option').css('max-width',maxWidth + 'px');
             button.addClass(this.style);
             if (this.size && this.$newElement.find('.dropdown-menu ul li').length > this.size) {
                 var menuA = this.$newElement.find('.dropdown-menu ul li > a');

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -50,8 +50,8 @@
             var template =
                 "<div class='btn-group bootstrap-select'>" +
                     "<button class='btn dropdown-toggle clearfix' data-toggle='dropdown'>" +
-                        "<span class='filter-option pull-left'>__SELECTED_OPTION</span> " +
-                        "<span class='caret pull-right'></span>" +
+                        "<span class='filter-option pull-left'>__SELECTED_OPTION</span>&nbsp;" +
+                        "<span class='caret'></span>" +
                     "</button>" +
                     "<div class='dropdown-menu' role='menu'>" +
                         "<ul>" +
@@ -115,6 +115,7 @@
                     // Trigger select 'change'
                     $select.prev('select').trigger('change');
                 }
+
             });
             this.$element.on('change', function(e) {
                 var selected = $(this).find('option:selected').text();
@@ -138,9 +139,9 @@
             }
         });
     };
-
+    
     $.fn.selectpicker.defaults = {
-        style: null,
+        style: null, 
         size: null
     }
 


### PR DESCRIPTION
I originally set the width of `.filter-option` using Javascript for cases where the text was too long to fit inside the `.btn`. This was causing issues if the `select` was initially hidden on page load (like if it was in a tab or modal that wasn't yet displayed). I went back through and removed the Javascript setting - now it is all set using CSS.
