### PR TITLE
focus button when associated label is clicked

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -36,6 +36,7 @@
             button = this.$newElement.find('> button');
             if (id !== undefined) {
                 button.attr('id', id);
+                $('label[for="' + id + '"]').click(function(){ button.focus(); })                
             }
             for (var i = 0; i < classList.length; i++) {
                 if(classList[i] != 'selectpicker') {


### PR DESCRIPTION
Just a little patch to set focus to the button when a label associated with the original select element has been clicked.
