### PR TITLE
support for updating UI after changes made to the select element

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -271,6 +271,17 @@
             if (!data) {
                 $this.data('selectpicker', (data = new Selectpicker(this, options, event)));
             }
+            // the select picker is already initalized; kill the UI element and rebuild it.
+            // If you added disabled="disabled" attributes to any of your options in the original element, the changes will be reflected here.
+            else {
+                // remove the stuff we added
+                data.$newElement.remove();
+                // Test if the current selected item is disabled; if so, de-select it.
+                var current = data.$element.find(':selected');
+                if(current.attr('disabled') === 'disabled') current.removeAttr('selected');
+                // re-init and rebuild
+                data.init();
+            }
             if (typeof option == 'string') {
                 data[option]();
             }


### PR DESCRIPTION
Example:

// add a disabled attribute to some options based on the value:
var select = $(mySelectElement);
select.find('option[value^="p-"]').attr('disabled', 'disabled');
// refresh the ui
select.selectpicker();

select.selectpicker();

N.B.

The previous pull request ( https://github.com/silviomoreto/bootstrap-select/pull/88 ) had messed up formatting, not showing the changes clearly. This one should be a lot better. My appologies for the mess :)
