### PR TITLE
Add "remove" param for setStyle method to be able to remove classes

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -245,6 +245,8 @@
 
             if (status == 'add') {
                 this.$button.addClass(buttonClass);
+            } else if (status == 'remove') {
+                this.$button.removeClass(buttonClass);
             } else {
                 this.$button.removeClass(this.options.style);
                 this.$button.addClass(buttonClass);


### PR DESCRIPTION
We need to be able to remove classes that have been added via setStyle.
At the moment it's only possible to replace/remove classes which have been initially set via {style: ...}.
setStyle method is extended to be able to remove classes.
