### PR TITLE
Fix events on pressed "Spacebar" and "Enter"

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -575,12 +575,8 @@
 
             // select focused option if "Enter" or "Spacebar" are pressed
             if (/(13|32)/.test(e.keyCode)) {
+                e.preventDefault();
                 $(':focus').click();
-                if (!that.multiple) {
-                    $parent.parent().toggleClass('open', !(e.keyCode == 32));
-                } else {
-                    e.preventDefault();
-                };
                 $(document).data('keycount',0);
             }
         },


### PR DESCRIPTION
I tested: on Linux - Chromium, Firefox and Opera, on OS X - Chrome, Firefox, Opera and Safari.

Issue only not multiple select when select open and focused button (not "dropdown-menu *")
1. When pressed "Spacebar" select reopened instead of closing.
2. When pressed "Enter" select does not close.

I remove toggleClass('open') because this not needed, "open" class correctly toggled.
Multiple select correct work befor and after fix.
