### PR TITLE
Bootstrap 3 "form-control" class support

### DIFF
--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -19,6 +19,15 @@
     margin-bottom: 0;
 }
 
+.bootstrap-select.form-control {
+    padding: 0;
+    border: none;
+}
+
+.bootstrap-select.form-control:not([class*="span"]) {
+    width: 100%;
+}
+
 .bootstrap-select.btn-group.pull-right,
 .bootstrap-select.btn-group[class*="span"].pull-right,
 .row-fluid .bootstrap-select.btn-group[class*="span"].pull-right {

--- a/test.html
+++ b/test.html
@@ -37,5 +37,26 @@
             <option>Ble</option>
         </optgroup>
     </select>
+
+    <div class="container">
+        <form class="form-horizontal" role="form">
+            <div class="form-group">
+                <label for="bs3Select" class="col-lg-2 control-label">Test bootstrap 3 form</label>
+                <div class="col-lg-10">
+                    <select id="bs3Select" class="selectpicker show-tick form-control" multiple data-live-search="true">
+                        <option>cow</option>
+                        <option>bull</option>
+                        <option class="get-class" disabled>ox</option>
+                        <optgroup label="test" data-subtext="another test" data-icon="icon-ok">
+                            <option>ASD</option>
+                            <option selected>Bla</option>
+                            <option>Ble</option>
+                        </optgroup>
+                    </select>
+                </div>
+              </div>
+        <form>
+    </div>
+
 </body>
 </html>


### PR DESCRIPTION
A simple fix for Bootstrap 3 "form-control" class.
Should fix #336.

The new CSS has not been minified because I can't find the command used.
