### PR TITLE
Added option to change separator character for multiple selections

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -226,7 +226,7 @@
 
             //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
             //Convert all the values into a comma delimited string
-            var title = !this.multiple ? selectedItems[0] : selectedItems.join(", ");
+            var title = !this.multiple ? selectedItems[0] : selectedItems.join(this.options.multipleSeparator);
 
             //If this is multi select, and the selectText type is count, the show 1 of 2 selected etc..
             if (this.multiple && this.options.selectedTextFormat.indexOf('count') > -1) {
@@ -724,7 +724,8 @@
         showContent: true,
         dropupAuto: true,
         header: false,
-        liveSearch: false
+        liveSearch: false,
+        multipleSeparator: ', '
     };
 
     $(document)


### PR DESCRIPTION
Useful when styling the display as labels, etc, as sometimes a space or pipe character may be preferred to a comma.
