### PR TITLE
Fix spacebar causing page to scroll due to key event being moved to keyu...

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -579,10 +579,18 @@
 
         keydown: function(e) {
             var that = $(this).parent().data('this');
+            var $this = $(this);
             // If the dropdown is closed, open it and move focus to the search box, if there is one.
             if(that.$searchbox && that.$searchbox.is(':not(:visible)') && e.keyCode >= 48 && e.keyCode <= 90) {
                 $(':focus').click();
                 that.$searchbox.focus();
+            }
+
+            // Select focused option if "Enter", "Spacebar", "Tab" are pressed inside the menu.
+            if (/(13|32|9)/.test(e.keyCode) && $this.is('[role=menu]')) {
+                $(':focus').click();
+                e.preventDefault();
+                $(document).data('keycount',0);
             }
         },
 
@@ -646,13 +654,6 @@
                 }
 
                 $items.eq(keyIndex[count - 1]).focus();
-            }
-
-            // Select focused option if "Enter", "Spacebar", "Tab" are pressed inside the menu.
-            if (/(13|32|9)/.test(e.keyCode) && $this.is('[role=menu]')) {
-                e.preventDefault();
-                $(':focus').click();
-                $(document).data('keycount',0);
             }
         },
 


### PR DESCRIPTION
Fixes issue #389 due to a change made in 1.3.5 to move the spacebar/tab/enter events to keyup.  This causes a problem if a user uses the spacebar to select an element, if the page can scroll then using space would scroll the page.
