### PR TITLE
Update bootstrap-select.js

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -58,6 +58,7 @@
 
             if (id !== undefined) {
                 var that = this;
+                this.$button.attr('id', id+'-bootstrap-select');
                 this.$button.attr('data-id', id);
                 $('label[for="' + id + '"]').click(function(e) {
                     e.preventDefault();


### PR DESCRIPTION
add an id to the created button so it can be found properly by jquery-validationEngine.js (if there are two or more bootstrap-selects on a page only one will be found properly - unless there's an id tag)
