### PR TITLE
Added ability to choose custom icon type

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -193,7 +193,7 @@
         createA: function(text, classes, inline) {
             return '<a tabindex="0" class="'+classes+'" style="'+inline+'">' +
                  text +
-                 '<i class="' + this.options.iconBase + ' ' + this.options.tickIcon + ' icon-ok check-mark"></i>' +
+                 '<i class="' + this.options.iconBase + ' ' + this.options.tickIcon + ' ' + this.options.iconClass + '"></i>' +
                  '</a>';
         },
 
@@ -849,7 +849,8 @@
         liveSearch: false,
         multipleSeparator: ', ',
         iconBase: 'glyphicon',
-        tickIcon: 'glyphicon-ok'
+        tickIcon: 'glyphicon-ok',
+        iconClass: 'icon-ok'
     };
 
     $(document)


### PR DESCRIPTION
Hi there,

On a project i had to use bootstrap-select without glyphicons.

On loading, set iconBase & tickIcon empty and iconClass, the icon class you want (no way !?)

Hope it will be useful.

Vincent
