### PR TITLE
Open menu and focus on option on any keypress

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -654,6 +654,12 @@
             $items = $('[role=menu] li:not(.divider) a', $parent);
             
             isActive = that.$menu.parent().hasClass('open');
+
+            if (!isActive && !/^9$/.test(e.keyCode)) {
+                that.$menu.parent().addClass('open');
+                isActive = that.$menu.parent().hasClass('open');
+                that.$searchbox.focus();
+            }
             
             if (that.options.liveSearch) {
                 if (/(^9$|27)/.test(e.keyCode) && isActive && that.$menu.find('.active').length === 0) {
@@ -672,10 +678,6 @@
             if (!$items.length) return;
 
             if (/(38|40)/.test(e.keyCode)) {
-                
-                if (!isActive) {
-                    that.$menu.parent().addClass('open');
-                }
                 
                 index = $items.index($items.filter(':focus'));
                 first = $items.parent(':not(.disabled):visible').first().index();


### PR DESCRIPTION
Move menu open out of up/down arrow to open on any keypress other than tab.  It will also focus on the first option that matches the key.

This makes the plugin work more similarly to system selects.

Fix #405 and #426 
