### PR TITLE
Fix options.title being ignored on render

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -230,7 +230,7 @@
 
             //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
             //Convert all the values into a comma delimited string
-            var title = !this.multiple ? selectedItems[0] : selectedItems.join(this.options.multipleSeparator);
+            var title = !this.multiple ? (this.options.title || selectedItems[0]) : selectedItems.join(this.options.multipleSeparator);
 
             //If this is multi select, and the selectText type is count, the show 1 of 2 selected etc..
             if (this.multiple && this.options.selectedTextFormat.indexOf('count') > -1) {


### PR DESCRIPTION
Title is being set to the first item even if options.title is specified.  Needs to check that its set before resorting to the first item.
