### PR TITLE
Fix bug with max-height and adjust which keys can open select

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -662,7 +662,8 @@
             
             isActive = that.$menu.parent().hasClass('open');
 
-            if (!isActive && !/^9$/.test(e.keyCode)) {
+            if (!isActive && /([0-9]|[A-z])/.test(String.fromCharCode(e.keyCode))) {
+                that.setSize();
                 that.$menu.parent().addClass('open');
                 isActive = that.$menu.parent().hasClass('open');
                 that.$searchbox.focus();


### PR DESCRIPTION
This fixes a bug with max-height we ran into with 1.4.3, basically the setSize would not have been called yet so in a list of 50 items the height of the menu would be the size of all 50 items.

This also changes the regex for when to open the dropdown on key click.  Rather than every key opening it it listens for numbers or letters, which makes it even more like a system select.  Before hitting control, shift, even caps lock would open it.
