### PR TITLE
Fix container option not working on keydown and index being off by 1 when data-hidden is used

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -54,6 +54,7 @@
             this.$element.hide();
             this.multiple = this.$element.prop('multiple');
             this.autofocus = this.$element.prop('autofocus');
+            this.hasHiddenTitle = false; // this is set to true on line 177 if <option data-hidden="true"> is used.
             this.$newElement = this.createView();
             this.$element.after(this.$newElement);
             this.$menu = this.$newElement.find('> .dropdown-menu');
@@ -173,6 +174,7 @@
                     _liA.push('<div class="div-contain"><div class="divider"></div></div>');
                 } else if ($(this).data('hidden') === true) {
                     _liA.push('');
+                    that.hasHiddenTitle = true;
                 } else {
                     _liA.push(that.createA(text, optionClass, inline ));
                 }
@@ -756,7 +758,7 @@
                 $items.each(function() {
                     if ($(this).parent().is(':not(.disabled)')) {
                         if ($.trim($(this).text().toLowerCase()).substring(0,1) == keyCodeMap[e.keyCode]) {
-                            keyIndex.push($(this).parent().index());
+                            keyIndex.push($(this).parent().index() - (that.hasHiddenTitle ? 1 : 0));
                         }
                     }
                 });
@@ -775,6 +777,7 @@
                     if (count > keyIndex.length) count = 1;
                 }
 
+                console.log($items, keyIndex[count - 1]);
                 $items.eq(keyIndex[count - 1]).focus();
             }
 

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -389,6 +389,15 @@
                 $drop.toggleClass('open', !$(this).hasClass('open'));
                 $drop.append(that.$menu);
             });
+            this.$newElement.on('keydown', function(e){
+                var isActive = that.$menu.parent().hasClass('open');
+                if (!isActive && /([0-9]|[A-z])/.test(String.fromCharCode(e.keyCode))) {
+                    getPlacement($(this));
+                    $drop.appendTo(that.options.container);
+                    $drop.toggleClass('open', !$(this).hasClass('open'));
+                    $drop.append(that.$menu);
+                }
+            });
             $(window).resize(function() {
                 getPlacement(that.$newElement);
             });

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -777,7 +777,6 @@
                     if (count > keyIndex.length) count = 1;
                 }
 
-                console.log($items, keyIndex[count - 1]);
                 $items.eq(keyIndex[count - 1]).focus();
             }
 


### PR DESCRIPTION
This fixes issue #466,  the menu not obeying the container option when opened using keydown.

This also fixes issue #475 where the index is off by 1 when data-hidden="true" is used to create a placeholder title.
