### PR TITLE
Labels with close buttons for multi-selects.

### DIFF
--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -6,6 +6,44 @@
  * Licensed under the MIT license
  */
 
+.label.bootstrap-select-label {
+    position: relative;
+    top: -2px;
+    margin-right: 5px;
+    padding-right: 18px;
+    border: 1px solid #AAA;
+    border-radius: 3px;
+    background-color: #E4E4E4;
+    color: #333;
+    font-weight: normal;
+    
+    background-image: -webkit-gradient(linear, 50% 0%, 50% 100%, color-stop(20%, #f4f4f4), color-stop(50%, #f0f0f0), color-stop(52%, #e8e8e8), color-stop(100%, #eeeeee));
+    background-image: -webkit-linear-gradient(#f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+    background-image: -moz-linear-gradient(#f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+    background-image: -o-linear-gradient(#f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+    background-image: linear-gradient(#f4f4f4 20%, #f0f0f0 50%, #e8e8e8 52%, #eeeeee 100%);
+    background-clip: padding-box;
+    box-shadow: 0 0 2px white inset, 0 1px 0 rgba(0, 0, 0, 0.05);
+    cursor: default;
+}
+
+.label.bootstrap-select-label > span {
+    vertical-align: baseline;
+}
+
+.label.bootstrap-select-label .bootstrap-select-close {
+    float: none;
+    position: absolute;
+    top: -4px;
+    right: 5px;
+    font-size: 19px;
+    opacity: 0.4;
+}
+
+.label.bootstrap-select-label .bootstrap-select-close:hover {
+    opacity: 0.75;
+}
+
 .bootstrap-select.btn-group,
 .bootstrap-select.btn-group[class*="span"] {
     float: none;
@@ -41,6 +79,11 @@
 
 .bootstrap-select:not([class*="span"]):not([class*="col-"]):not([class*="form-control"]) {
     width: 220px;
+}
+
+.bootstrap-select.labels:not([class*="span"]):not([class*="col-"]):not([class*="form-control"]) {
+    min-width: 220px;
+    width: auto;
 }
 
 .bootstrap-select {
@@ -80,6 +123,13 @@
     position: absolute;
     left: 12px;
     right: 25px;
+    text-align: left;
+}
+
+.bootstrap-select.labels.btn-group .btn .filter-option {
+    overflow: visible;
+    position: static;
+    margin-right: 15px;
     text-align: left;
 }
 

--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -8,8 +8,8 @@
 
 .label.bootstrap-select-label {
     position: relative;
-    top: -2px;
     margin-right: 5px;
+    margin-bottom: 6px;
     padding-right: 18px;
     border: 1px solid #AAA;
     border-radius: 3px;
@@ -84,7 +84,12 @@
 
 .bootstrap-select.labels:not([class*="span"]):not([class*="col-"]):not([class*="form-control"]) {
     min-width: 220px;
+    max-width: 300px;
     width: auto;
+}
+
+.bootstrap-select.labels > button {
+    padding-bottom: 0px;
 }
 
 .bootstrap-select {

--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -29,6 +29,7 @@
 
 .label.bootstrap-select-label > span {
     vertical-align: baseline;
+    margin-right: 3px;
 }
 
 .label.bootstrap-select-label .bootstrap-select-close {
@@ -36,7 +37,7 @@
     position: absolute;
     top: -4px;
     right: 5px;
-    font-size: 19px;
+    font-size: 20px;
     opacity: 0.4;
 }
 

--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -92,6 +92,10 @@
     padding-bottom: 0px;
 }
 
+.bootstrap-select.labels .filter-option .nothing-selected {
+    margin-bottom: 4px; 
+}
+
 .bootstrap-select {
     /*width: 220px\9; IE8 and below*/
     width: 220px\0; /*IE9 and below*/
@@ -130,6 +134,7 @@
     left: 12px;
     right: 25px;
     text-align: left;
+    float: left;
 }
 
 .bootstrap-select.labels.btn-group .btn .filter-option {

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -264,7 +264,7 @@
 
             this.$button.attr('title', $.trim(title));
             var $filterOption = this.$newElement.find('.filter-option');
-            $filterOption.html(titleHTML || title);
+            $filterOption.html(titleHTML || '<div class="nothing-selected">' + title + '</div>');
 
             if (this.options.labels) {
                 // Detect clicks on the 'remove' button for each label.

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -90,7 +90,7 @@
             var drop =
                 '<div class="btn-group bootstrap-select' + multiple + labels + '">' +
                     '<button type="button" class="btn dropdown-toggle selectpicker" data-toggle="dropdown"'+ autofocus +'>' +
-                        '<span class="filter-option pull-left"></span>&nbsp;' +
+                        '<div class="filter-option"></div>&nbsp;' +
                         '<span class="caret"></span>' +
                     '</button>' +
                     '<div class="dropdown-menu open">' +
@@ -239,12 +239,12 @@
                 for (var i in selectedItems) {
                     var escapedVal = encodeURIComponent(selectedItems[i]);
                     titleHTML +=
-                        '<div class="label label-default bootstrap-select-label">' +
+                        '<span class="label label-default bootstrap-select-label pull-left">' +
                             '<span>' + selectedItems[i] + '</span>' + 
                             '<a class="close bootstrap-select-close" ' + 
                                  'title="Unselect ' + escapedVal + '" ' +
                                  'data-value="' + escapedVal + '">&times;</a>' +
-                        '</div>';
+                        '</span>';
                 }
             }
 

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -84,10 +84,11 @@
             //If we are multiple, then add the show-tick class by default
             var multiple = this.multiple ? ' show-tick' : '';
             var autofocus = this.autofocus ? ' autofocus' : '';
+            var labels = this.options.labels ? ' labels' : '';
             var header = this.options.header ? '<div class="popover-title"><button type="button" class="close" aria-hidden="true">&times;</button>' + this.options.header + '</div>' : '';
             var searchbox = this.options.liveSearch ? '<div class="bootstrap-select-searchbox"><input type="text" class="input-block-level form-control" /></div>' : '';
             var drop =
-                '<div class="btn-group bootstrap-select' + multiple + '">' +
+                '<div class="btn-group bootstrap-select' + multiple + labels + '">' +
                     '<button type="button" class="btn dropdown-toggle selectpicker" data-toggle="dropdown"'+ autofocus +'>' +
                         '<span class="filter-option pull-left"></span>&nbsp;' +
                         '<span class="caret"></span>' +
@@ -230,7 +231,20 @@
 
             //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
             //Convert all the values into a comma delimited string
-            var title = !this.multiple ? selectedItems[0] : selectedItems.join(this.options.multipleSeparator);
+            var title = '';
+            if (this.multiple) {
+                if (this.options.labels) {
+                    for (var i in selectedItems) {
+                        title +=
+                            '<div class="label label-default bootstrap-select-label">' +
+                                '<span>' + selectedItems[i] + '</span>' + 
+                                ' <a class="close bootstrap-select-close">&times;</a>' +
+                            '</div>';
+                    }
+                } else
+                    title = selectedItems.join(this.options.multipleSeparator);
+            } else
+                title = selectedItems[0];
 
             //If this is multi select, and the selectText type is count, the show 1 of 2 selected etc..
             if (this.multiple && this.options.selectedTextFormat.indexOf('count') > -1) {
@@ -247,7 +261,14 @@
             }
 
             this.$button.attr('title', $.trim(title));
-            this.$newElement.find('.filter-option').html(title);
+            var $filterOption = this.$newElement.find('.filter-option');
+            $filterOption.html(title);
+
+            if (this.options.labels) {
+                $('.bootstrap-select-close', $filterOption).click(function(e) {
+                    debugger;
+                });
+            }
         },
 
         setStyle: function(style, status) {
@@ -860,7 +881,8 @@
         liveSearch: false,
         multipleSeparator: ', ',
         iconBase: 'glyphicon',
-        tickIcon: 'glyphicon-ok'
+        tickIcon: 'glyphicon-ok',
+        labels: false // If true, will show chosen style labels. This only works with multi-selects.
     };
 
     $(document)

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -241,7 +241,7 @@
                     titleHTML +=
                         '<div class="label label-default bootstrap-select-label">' +
                             '<span>' + selectedItems[i] + '</span>' + 
-                            ' <a class="close bootstrap-select-close" ' + 
+                            '<a class="close bootstrap-select-close" ' + 
                                  'title="Unselect ' + escapedVal + '" ' +
                                  'data-value="' + escapedVal + '">&times;</a>' +
                         '</div>';

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -264,7 +264,7 @@
 
             this.$button.attr('title', $.trim(title));
             var $filterOption = this.$newElement.find('.filter-option');
-            $filterOption.html(titleHTML);
+            $filterOption.html(titleHTML || title);
 
             if (this.options.labels) {
                 // Detect clicks on the 'remove' button for each label.

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -276,7 +276,7 @@
                     var val = $closeBtn.data('value');
                     $('option', that.$element).each(function() {
                         var $option = $(this);
-                        if ($option.attr('value') !== val && $option.text() !== val) return;
+                        if ($option.attr('value') !== val && $option.text() !== decodeURIComponent(val)) return;
                         $option.removeAttr('selected');
                     });
                     // Calling change() calls render but does not updateLIs.

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -231,20 +231,22 @@
 
             //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
             //Convert all the values into a comma delimited string
-            var title = '';
-            if (this.multiple) {
-                if (this.options.labels) {
-                    for (var i in selectedItems) {
-                        title +=
-                            '<div class="label label-default bootstrap-select-label">' +
-                                '<span>' + selectedItems[i] + '</span>' + 
-                                ' <a class="close bootstrap-select-close">&times;</a>' +
-                            '</div>';
-                    }
-                } else
-                    title = selectedItems.join(this.options.multipleSeparator);
-            } else
-                title = selectedItems[0];
+            var title = !this.multiple ? selectedItems[0] : selectedItems.join(this.options.multipleSeparator);
+            var titleHTML = title;
+
+            if (this.multiple && this.options.labels) {
+                titleHTML = '';
+                for (var i in selectedItems) {
+                    var escapedVal = encodeURIComponent(selectedItems[i]);
+                    titleHTML +=
+                        '<div class="label label-default bootstrap-select-label">' +
+                            '<span>' + selectedItems[i] + '</span>' + 
+                            ' <a class="close bootstrap-select-close" ' + 
+                                 'title="Unselect ' + escapedVal + '" ' +
+                                 'data-value="' + escapedVal + '">&times;</a>' +
+                        '</div>';
+                }
+            }
 
             //If this is multi select, and the selectText type is count, the show 1 of 2 selected etc..
             if (this.multiple && this.options.selectedTextFormat.indexOf('count') > -1) {
@@ -262,11 +264,25 @@
 
             this.$button.attr('title', $.trim(title));
             var $filterOption = this.$newElement.find('.filter-option');
-            $filterOption.html(title);
+            $filterOption.html(titleHTML);
 
             if (this.options.labels) {
+                // Detect clicks on the 'remove' button for each label.
                 $('.bootstrap-select-close', $filterOption).click(function(e) {
-                    debugger;
+                    var $closeBtn = $(this);
+                    e.stopPropagation();
+                    // Find the option with the value below.
+                    // De-select and call render.
+                    var val = $closeBtn.data('value');
+                    $('option', that.$element).each(function() {
+                        var $option = $(this);
+                        if ($option.attr('value') !== val && $option.text() !== val) return;
+                        $option.removeAttr('selected');
+                    });
+                    // Calling change() calls render but does not updateLIs.
+                    that.$element.change();
+                    // The LIs need to be updated.
+                    that.render();
                 });
             }
         },

--- a/test.html
+++ b/test.html
@@ -77,7 +77,7 @@
     <label for="id_select_label">Multi-select with labels</label>
     <select id="id_select_label" class="selectpicker bla bla bli" multiple data-live-search="true">
         <option>cow</option>
-        <option>bull</option>
+        <option selected>bull</option>
         <option class="get-class" disabled>ox</option>
         <optgroup label="test" data-subtext="another test" data-icon="icon-ok">
             <option>ASD</option>

--- a/test.html
+++ b/test.html
@@ -26,6 +26,8 @@
             $('#id_select_label').selectpicker({
                 'selectedText': 'cat',
                 'labels': true
+            }).change(function() {
+                console.log($(this).val());
             });
 
             // $('.selectpicker').selectpicker('hide');

--- a/test.html
+++ b/test.html
@@ -83,6 +83,8 @@
             <option>ASD</option>
             <option selected>Bla</option>
             <option>Ble</option>
+            <option>Testing spaces</option>
+            <option value="Testing other characters ^%/ ., @!">Testing other characters ^%/ ., @!</option>
         </optgroup>
     </select>
 

--- a/test.html
+++ b/test.html
@@ -17,8 +17,15 @@
     <script type="text/javascript">
         $(window).on('load', function () {
 
-            $('.selectpicker').selectpicker({
+            $('#id_select').selectpicker({
                 'selectedText': 'cat'
+            });
+            $('#bs3Select').selectpicker({
+                'selectedText': 'cat'
+            });
+            $('#id_select_label').selectpicker({
+                'selectedText': 'cat',
+                'labels': true
             });
 
             // $('.selectpicker').selectpicker('hide');
@@ -30,6 +37,13 @@
     <select id="id_select" class="selectpicker bla bla bli" multiple data-live-search="true">
         <option>cow</option>
         <option>bull</option>
+        <option>test</option>
+        <option>another</option>
+        <option>couch</option>
+        <option>television</option>
+        <option>aliens</option>
+        <option>dogs</option>
+        <option>computer</option>
         <option class="get-class" disabled>ox</option>
         <optgroup label="test" data-subtext="another test" data-icon="icon-ok">
             <option>ASD</option>
@@ -57,6 +71,18 @@
               </div>
         <form>
     </div>
+
+    <label for="id_select_label">Multi-select with labels</label>
+    <select id="id_select_label" class="selectpicker bla bla bli" multiple data-live-search="true">
+        <option>cow</option>
+        <option>bull</option>
+        <option class="get-class" disabled>ox</option>
+        <optgroup label="test" data-subtext="another test" data-icon="icon-ok">
+            <option>ASD</option>
+            <option selected>Bla</option>
+            <option>Ble</option>
+        </optgroup>
+    </select>
 
 </body>
 </html>


### PR DESCRIPTION
This plugin is great but I felt the multi-select could be improved from a usability point of view. The labels are 'opt-in' via the `'labels': true` property. Refer to the last select on `test.html` for a demo.
###### Issues:
- Limited width of the select box causes many selected options to be hidden.
- Readability of comma delimited list of strings.
- There is no way to remove selected options without opening the select box.
###### Improvements (Only for multi-selects):
- Labels are used instead of a comma delimited list of strings.
- Labels have a click-able 'unselect' button. Users can unselect options without opening the select box.
- The select box grows as more options are selected.
