### PR TITLE
click trigger on option

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -527,6 +527,9 @@
                     if ((prevValue != that.$element.val() && that.multiple) || (prevIndex != that.$element.prop('selectedIndex') && !that.multiple)) {
                         that.$element.change();
                     }
+
+                    // Trigger option 'click'
+                    $option.click();
                 }
             });
 


### PR DESCRIPTION
Click on tool didn't fire click event on option. For getting option value it can be useful. 
