### PR TITLE
A disabled dropdown would still open when clicked when the container property is set

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -409,6 +409,9 @@
                     $drop.css({'top' : pos.top + actualHeight, 'left' : pos.left, 'width' : $element[0].offsetWidth, 'position' : 'absolute'});
                 };
             this.$newElement.on('click', function() {
+                if (that.isDisabled()) {
+                    return;
+                }
                 getPlacement($(this));
                 $drop.appendTo(that.options.container);
                 $drop.toggleClass('open', !$(this).hasClass('open'));


### PR DESCRIPTION
Now check if the dropdown is disabled or not before opening it.
