### PR TITLE
added option for custom dropdown caret html

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -101,7 +101,7 @@
                 '<div class="btn-group bootstrap-select' + multiple + inputGroup + '">' +
                     '<button type="button" class="btn dropdown-toggle selectpicker" data-toggle="dropdown"'+ autofocus +'>' +
                         '<span class="filter-option pull-left"></span>&nbsp;' +
-                        '<span class="caret"></span>' +
+                        this.options.caretHTML +
                     '</button>' +
                     '<div class="dropdown-menu open">' +
                         header +
@@ -961,6 +961,7 @@
         multipleSeparator: ', ',
         iconBase: 'glyphicon',
         tickIcon: 'glyphicon-ok',
+        caretHTML: '<span class="caret"></span>',
         maxOptions: false
     };
 


### PR DESCRIPTION
As the title says I added the ability to specify the caret html as an option so that it can be replaced with something other than `<span class="caret"><span>`. I did this so that it can be used with other icon fonts.
See my working example: ![](https://cloud.githubusercontent.com/assets/4628721/3025809/4864847c-e00a-11e3-92f7-468c1e9d62fb.png).

``` javascript
$('.selectpicker').selectpicker({
    caretHTML: '<span class="entypo-down-open-big"></span>'
});
```
