### PR TITLE
Toggle value method

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -39,6 +39,7 @@
         this.refresh = Selectpicker.prototype.refresh;
         this.setStyle = Selectpicker.prototype.setStyle;
         this.selectAll = Selectpicker.prototype.selectAll;
+        this.toggleVal = Selectpicker.prototype.toggleVal;
         this.deselectAll = Selectpicker.prototype.deselectAll;
         this.init();
     };
@@ -704,6 +705,31 @@
             } else {
                 return this.$element.val();
             }
+        },
+
+        toggleVal: function(value) {
+            if (value !== undefined) {
+                var values = this.$element.val();
+
+                if (values === null) {
+                    this.$element.val(value);
+                }
+                else {
+                    var valueIndex = values.indexOf(value);
+
+                    if (valueIndex === -1) {
+                        values.push(value);
+                    } else {
+                        values.splice(valueIndex, 1);
+                    }
+
+                    this.$element.val(values);
+                }
+
+                this.$element.change();
+            }
+
+            return this.$element.val();
         },
 
         selectAll: function() {

--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -729,7 +729,7 @@
                 this.$element.change();
             }
 
-            return this.$element.val();
+            return this.$element;
         },
 
         selectAll: function() {


### PR DESCRIPTION
As there is currently no method to easily select or deselect a value based on its current state I implemented a toggleValue feature.

```
$('.myselect').selectpicker('toggleVal', 'myvalue');
```

The example selects "myvalue" if it is not already selected and deselects it in case it its already selected.

A major benefit of adding this to the API is that it supports the change event, that is triggered by the plugin itself.
