### PR TITLE
Fix for jquery.ValidationEngine.js compatibility

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -267,7 +267,7 @@
 
         setStyle: function(style, status) {
             if (this.$element.attr('class')) {
-                this.$newElement.addClass(this.$element.attr('class').replace(/selectpicker|mobile-device/gi, ''));
+                this.$newElement.addClass(this.$element.attr('class').replace(/selectpicker|mobile-device|validate\[.*\]/gi, ''));
             }
 
             var buttonClass = style ? style : this.options.style;


### PR DESCRIPTION
If you're trying to use:

bootstrap-select.js and jquery.validationEngine.js https://github.com/posabsolute/jQuery-Validation-Engine

You will most likely run into an issue where the selects will never seem to validate.

When bootstrap-select creates a cloned element, it uses an addClass that copies the validate[.*] class into the new div element, and validationEngine tries to validate that.

This can be remedied by modifying the setStyle function to strip that part of the class attribute out (at line 272 of bootstrap-select.js):

this.$newElement.addClass(this.$element.attr('class').replace(/selectpicker|mobile-device|validate[._]/gi, ''));
Note the change is simply: |validate[._] in the regular expression.

This keeps the new DIV element from being "validated" by the validationEngine script.

After adding this, validationEngine works for me with bootstrap-select. Huzzah!
