### PR TITLE
wrap by '.input-group-addon' support.

### DIFF
--- a/bootstrap-select.css
+++ b/bootstrap-select.css
@@ -311,3 +311,17 @@
 .bootstrap-select .bs-actionsbox .btn-group button {
     width: 50%;
 }
+
+
+.input-group-addon-bootstrap-select{
+    padding: 0px;
+}
+
+
+.input-group-addon .bootstrap-select > .btn {
+    border: none;
+    background: transparent;
+    border-radius: 0px;
+    box-shadow: none;
+    outline: none!important;
+}


### PR DESCRIPTION
the html template like this:

```
<div class="form-group">
    <div class="col-md-10 col-sm-10">
        <div class="input-group">
            <span class="input-group-addon input-group-addon-bootstrap-select">
                <select name="" id="" class="selectpicker ">
                    <option value="" data-content=''></option>
                </select>
            </span>
            <input type="text" placeholder="" class="form-control" >
        </div>
    </div>
</div>
```
