### PR TITLE
Made "mobile" a boolean option when instantiating the selectpicker

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -78,6 +78,7 @@
             if (this.options.container) this.selectPosition();
             this.$menu.data('this', this);
             this.$newElement.data('this', this);
+            if (this.options.mobile) this.mobile();
         },
 
         createDropdown: function() {
@@ -962,7 +963,8 @@
         multipleSeparator: ', ',
         iconBase: 'glyphicon',
         tickIcon: 'glyphicon-ok',
-        maxOptions: false
+        maxOptions: false,
+        mobile: false
     };
 
     $(document)


### PR DESCRIPTION
Currently you have to make two calls to create a mobile-friendly select: 
1. Instantiate bootstrap-select, e.g. `$('.selectpicker').selectpicker();`
2. Mobilify the select, e.g. `$('.selectpicker').mobile();`

I made a small change so `mobile` is an option that can be passed in when instantiating (defaults to `false`, of course), e.g. `$('.selectpicker').selectpicker({mobile : true});`

Here's a [fiddle](http://jsfiddle.net/jkrehm/4UjVr/) to illustrate the change (view it on a phone/tablet).

I did not update the documents branch with the new option.
