### PR TITLE
adding placeholder on input search

### DIFF
--- a/bootstrap-select.js
+++ b/bootstrap-select.js
@@ -86,7 +86,7 @@
             var inputGroup = this.$element.parent().hasClass('input-group') ? ' input-group-btn' : '';
             var autofocus = this.autofocus ? ' autofocus' : '';
             var header = this.options.header ? '<div class="popover-title"><button type="button" class="close" aria-hidden="true">&times;</button>' + this.options.header + '</div>' : '';
-            var searchbox = this.options.liveSearch ? '<div class="bootstrap-select-searchbox"><input type="text" class="input-block-level form-control" autocomplete="off" /></div>' : '';
+            var searchbox = this.options.liveSearch ? '<div class="bootstrap-select-searchbox"><input type="text" class="input-block-level form-control" autocomplete="off"  placeholder="'+(this.options.liveSearchTitle || '')+'" /></div>' : '';
             var actionsbox = this.options.actionsBox ? '<div class="bs-actionsbox">' +
                                 '<div class="btn-group btn-block">' +
                                     '<button class="actions-btn bs-select-all btn btn-sm btn-default">' +


### PR DESCRIPTION
now you can add a placeholder for search input
Example:
`<select class="selectpicker" data-live-search="true" data-live-search-title="Search"></select>`
