### PR TITLE
Fix Memory Leak by re-scoping touchstart

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -527,7 +527,7 @@
     clickListener: function () {
       var that = this;
 
-      $('body').on('touchstart.dropdown', '.dropdown-menu', function (e) {
+      this.$newElement.on('touchstart.dropdown', '.dropdown-menu', function (e) {
         e.stopPropagation();
       });
 


### PR DESCRIPTION
Fix Memory Leak (detached DOM elements remaining in scope after destroy in a SPA app) by scoping the touchstart event to the children of this.$newElement -- which preserves the desired behavior while creating this event such that it will automatically be removed when "destroy" occurs.

This resolves issues 578 and 582.   Without this fix, in a SPA app, the DOM element remains in scope after destroy due to the touchstart handler.  
