### PR TITLE
Simplify README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ bootstrap-select
 
 [![Latest release](http://img.shields.io/github/release/silviomoreto/bootstrap-select.svg)](https://github.com/silviomoreto/bootstrap-select/releases/latest)
 [![Dependency Status](https://david-dm.org/silviomoreto/bootstrap-select.svg)](https://david-dm.org/silviomoreto/bootstrap-select)
-[![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](http://opensource.org/licenses/MIT)
+[![License](https://img.shields.io/badge/license-MIT-brightgreen.svg)](LICENSE)
 
 [![devDependency Status](https://david-dm.org/silviomoreto/bootstrap-select/dev-status.svg)](https://david-dm.org/silviomoreto/bootstrap-select#info=devDependencies)
 
@@ -11,14 +11,14 @@ A custom select / multiselect for Bootstrap using button dropdown, designed to b
 
 ## Demo and Documentation
 
-See a Bootstrap 3.2 example [here](http://silviomoreto.github.com/bootstrap-select/3).
+See a Bootstrap 3.2.0 example [here](http://silviomoreto.github.io/bootstrap-select/3).
 
-See a Bootstrap 2.3.2 example [here](http://silviomoreto.github.com/bootstrap-select/) (deprecated).
+See a Bootstrap 2.3.2 example [here](http://silviomoreto.github.io/bootstrap-select) (deprecated).
 
 ## Authors
 
-[Silvio Moreto](http://github.com/silviomoreto),
-[Ana Carolina](http://github.com/anacarolinats),
+[Silvio Moreto](https://github.com/silviomoreto),
+[Ana Carolina](https://github.com/anacarolinats),
 [caseyjhol](https://github.com/caseyjhol),
 [Matt Bryson](https://github.com/mattbryson), and
 [t0xicCode](https://github.com/t0xicCode).
@@ -45,15 +45,15 @@ $('select').selectpicker();
 
 ***Starting with the current dev version, we support bootstrap's data-api, which means that you don't even have to manually instanciate bootstrap-select.***
 
-Checkout the [documentation](http://silviomoreto.github.com/bootstrap-select/) for further information.
+Checkout the [documentation](http://silviomoreto.github.io/bootstrap-select) for further information.
 
 ## CDN
 
-**N.B.**: The CDN is updated after the release is made public, which means that there is a delay between the publishing of a release and its availability on the CDN. Check [the github page](https://github.com/silviomoreto/bootstrap-select/releases) for the latest release.
+**N.B.**: The CDN is updated after the release is made public, which means that there is a delay between the publishing of a release and its availability on the CDN. Check [the GitHub page](https://github.com/silviomoreto/bootstrap-select/releases) for the latest release.
 
+* [//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.2/css/bootstrap-select.min.css](//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.2/css/bootstrap-select.min.css)
 * [//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.2/js/bootstrap-select.min.js](//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.2/js/bootstrap-select.min.js)
 * //cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.2/js/i18n/defaults-*.min.js (The translation files)
-* [//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.2/css/bootstrap-select.min.css](//cdnjs.cloudflare.com/ajax/libs/bootstrap-select/1.6.2/css/bootstrap-select.min.css)
 
 ## Bugs and feature requests
 
@@ -67,10 +67,4 @@ review the [guidelines for contributing](CONTRIBUTING.md). Make sure you're usin
 
 Copyright (C) 2013-2014 bootstrap-select
 
-Licensed under the MIT license.
-
-Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
-
-The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+Licensed under [the MIT license](LICENSE).


### PR DESCRIPTION
1. Use silviomoreto.github.io instead silviomoreto.github.com.
2. Create link on LICENSE, and remove license information from README.md.
3. http://github.com -> https://github.com.
