### PR TITLE
Add 1 new method 'toggle', 2 new events 'onOpen' and 'onClose', and 1 new option 'searchBeginsWith'

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -622,6 +622,23 @@
 
       this.$newElement.on('click', function () {
         that.setSize();
+
+        var isActive = that.$menu.parent().hasClass('open');
+        if ( isActive )
+        {
+          if ( that.options.onClose !== undefined )
+          {
+            that.options.onClose();
+          }
+        }
+        else
+        {
+          if ( that.options.onOpen !== undefined )
+          {
+            that.options.onOpen();
+          }
+        }
+        
         if (!that.options.liveSearch && !that.multiple) {
           setTimeout(function () {
             that.$menu.find('.selected a').focus();

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -80,6 +80,7 @@
     this.remove = Selectpicker.prototype.remove;
     this.show = Selectpicker.prototype.show;
     this.hide = Selectpicker.prototype.hide;
+    this.toggle = Selectpicker.prototype.toggle;
 
     this.init();
   };
@@ -1060,6 +1061,10 @@
     remove: function () {
       this.$newElement.remove();
       this.$element.remove();
+    },
+    
+    toggle: function () {
+      this.$button.trigger('click');
     }
   };
 

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -929,6 +929,10 @@
           e.preventDefault();
           that.$menu.parent().removeClass('open');
           that.$button.focus();
+					if ( that.options.onClose !== undefined )
+					{
+						that.options.onClose();
+					}
         }
         $items = $('[role=menu] li:not(.divider):not(.dropdown-header):visible', $parent);
         if (!$this.val() && !/(38|40)/.test(e.keyCode.toString(10))) {
@@ -1041,6 +1045,10 @@
       if ((/(^9$|27)/.test(e.keyCode.toString(10)) && isActive && (that.multiple || that.options.liveSearch)) || (/(27)/.test(e.keyCode.toString(10)) && !isActive)) {
         that.$menu.parent().removeClass('open');
         that.$button.focus();
+				if ( that.options.onClose !== undefined )
+				{
+					that.options.onClose();
+				}
       }
     },
 

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -10,6 +10,16 @@
   $.expr[':'].aicontains = function (obj, index, meta) {
     return icontains($(obj).data('normalizedText') || $(obj).text(), meta[3]);
   };
+  
+  // Case insensitive search begins with
+  $.expr[':'].ibegins = function( obj, index, meta ) {
+    return ibegins( $(obj).text(), meta[3] );
+  };
+	
+  // Case and accent insensitive search begins with
+  $.expr[':'].aibegins = function( obj, index, meta ) {
+    return ibegins( $(obj).data('normalizedText') || $(obj).text(), meta[3] );
+  };
 
   /**
    * Actual implementation of the case insensitive search.
@@ -20,6 +30,10 @@
    */
   function icontains(haystack, needle) {
     return haystack.toUpperCase().indexOf(needle.toUpperCase()) > -1;
+  }
+  
+  function ibegins( haystack, needle ) {
+    return haystack.toUpperCase().indexOf(needle.toUpperCase()) == 0;
   }
 
   /**
@@ -125,7 +139,8 @@
     mobile: false,
     selectOnTab: false,
     dropdownAlignRight: false,
-    searchAccentInsensitive: false
+    searchAccentInsensitive: false,
+    searchBeginsWith: false
   };
 
   Selectpicker.prototype = {
@@ -822,10 +837,21 @@
       this.$searchbox.on('input propertychange', function () {
         if (that.$searchbox.val()) {
 
-          if (that.options.searchAccentInsensitive) {
-            that.$lis.not('.is-hidden').removeClass('hide').find('a').not(':aicontains(' + normalizeToBase(that.$searchbox.val()) + ')').parent().addClass('hide');
-          } else {
-            that.$lis.not('.is-hidden').removeClass('hide').find('a').not(':icontains(' + that.$searchbox.val() + ')').parent().addClass('hide');
+          if ( ( that.options.searchAccentInsensitive ) && ( that.options.searchBeginsWith ) )
+          {
+          	that.$lis.not('.is-hidden').removeClass('hide').find('a').not(':aibegins(' + normalizeToBase(that.$searchbox.val()) + ')').parent().addClass('hide');
+          }
+          else if ( ( ! that.options.searchAccentInsensitive ) && ( that.options.searchBeginsWith ) )
+          {
+          	that.$lis.not('.is-hidden').removeClass('hide').find('a').not(':ibegins(' + that.$searchbox.val() + ')').parent().addClass('hide');
+          }
+          else if ( ( that.options.searchAccentInsensitive ) && ( ! that.options.searchBeginsWith ) )
+          {
+          	that.$lis.not('.is-hidden').removeClass('hide').find('a').not(':aicontains(' + normalizeToBase(that.$searchbox.val()) + ')').parent().addClass('hide');
+          }
+          else if ( ( ! that.options.searchAccentInsensitive ) && ( ! that.options.searchBeginsWith ) )
+          {
+          	that.$lis.not('.is-hidden').removeClass('hide').find('a').not(':icontains(' + that.$searchbox.val() + ')').parent().addClass('hide');
           }
 
           if (!that.$menu.find('li').filter(':visible:not(.no-results)').length) {


### PR DESCRIPTION
Commit 1 adds a new method, 'toggle' to programmatically open and close a bootstrap-select drop-down, eg:
$('.selectpicker').selectpicker('toggle');

Commit 2 adds two new events 'onOpen' and 'onClose' so that user can subscribe in the options of bootstrap-select like so:
$('.selectpicker').selectpicker
(
  {
    onOpen : function()
    {
      alert("now open");
    },
    onClose : function()
    {
      alert("now closed");
    }
  }
);

Commit 3 adds some more 'onClose' hooks so it works properly on key events.

Commit 4 adds an option 'searchBeginsWith' which when set to true does a LiveSearch only from beginning of the word, more like autocomplete.
