### PR TITLE
Fix to index of list items

### DIFF
--- a/dist/js/bootstrap-select.js
+++ b/dist/js/bootstrap-select.js
@@ -279,7 +279,7 @@
             subtext = typeof $this.data('subtext') !== 'undefined' ? '<small class="muted text-muted">' + $this.data('subtext') + '</small>' : '',
             icon = typeof $this.data('icon') !== 'undefined' ? '<span class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></span> ' : '',
             isDisabled = $this.is(':disabled') || $this.parent().is(':disabled'),
-            index = $this[0].index;
+            index = $this.index();
         if (icon !== '' && isDisabled) {
           icon = '<span>' + icon + '</span>';
         }


### PR DESCRIPTION
There was a small problem with the rendering in IE11 that set the data-original-index of all items to 0. This change corrects that issue.
