### PR TITLE
Run a trim on the title before setting the title attribute on the button

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -406,7 +406,7 @@
         title = typeof this.options.title !== 'undefined' ? this.options.title : this.options.noneSelectedText;
       }
 
-      this.$button.attr('title', htmlEscape(title));
+      this.$button.attr('title', htmlEscape($.trim(title)));
       this.$newElement.find('.filter-option').html(title);
     },
 


### PR DESCRIPTION
Fixes problems with strangely formatted title boxes.
