### PR TITLE
Fixed dropdown selection using space bar

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -750,7 +750,9 @@
           }
 
           if (!that.multiple) {
-            that.$button.focus();
+              setTimeout(function () { // BUG FIX: Fixes spacebar selection of dropdown items in FF & IE
+                  that.$button.focus();
+              }, 50);
           } else if (that.options.liveSearch) {
             that.$searchbox.focus();
           }


### PR DESCRIPTION
Due to a timing issue in Firefox (tested v33.1) and IE (tested v10) when a user attempts to select a dropdown item using the space bar the dropdown menu briefly closes but then reopens itself.  This works correctly in Chrome.  The fix for this was to ensure that the button is set to focus after the other operations are done on the dropdown menu.
