### PR TITLE
Fixed less compiling issue

### DIFF
--- a/less/bootstrap-select.less
+++ b/less/bootstrap-select.less
@@ -226,7 +226,7 @@
 
 .bootstrap-select.show-menu-arrow {
   &.open > .btn {
-    z-index: @zindex-select-dropdown + 1;
+    z-index: (@zindex-select-dropdown + 1);
   }
 
   .dropdown-toggle {


### PR DESCRIPTION
https://github.com/silviomoreto/bootstrap-select/blob/master/less/bootstrap-select.less#L229

This compiles into 

<pre>.bootstrap-select.show-menu-arrow.open > .btn {
  z-index: 1035 + 1;                                                                                                               
}
</pre>


which is not valid CSS syntax.

Math oparations should be wrapped with parantheses.
