### PR TITLE
Fix bug .selectpicker("val", "xxx") not work in ie9

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1146,7 +1146,14 @@
   // ==============================
   function Plugin(option, event) {
     // get the args of the outer function..
-    var args = arguments;
+    //var args = arguments;
+	//Fix bug:
+	//			.selectpicker("val", "xxx") not work in ie9 #775
+	var args = [];
+    for (var i = 0, length = arguments.length; i < length; i++) {
+        args.push(arguments[i]);
+    }
+	
     // The arguments of the function are explicitly re-defined from the argument list, because the shift causes them
     // to get lost
     //noinspection JSDuplicatedDeclaration


### PR DESCRIPTION
Fix that bug,this is some different processs for arguments in IE9,I
build a array,and push the item of arguments into my array one by
one,and it can work well
