### PR TITLE
Fix keycode range that triggers opening

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1238,7 +1238,7 @@
 
       isActive = that.$menu.parent().hasClass('open');
 
-      if (!isActive && /([0-9]|[A-z])/.test(String.fromCharCode(e.keyCode))) {
+      if (!isActive && (e.keyCode >= 48 && e.keyCode <= 57 || event.keyCode >= 65 && event.keyCode <= 90)) {
         if (!that.options.container) {
           that.setSize();
           that.$menu.parent().addClass('open');


### PR DESCRIPTION
Maybe nitpicky, but function keys (e.g. F5, F6, ...) open the select (when it has focus) because the keycode range detection is incorrect.  This is reproducible on all the examples at http://silviomoreto.github.io/bootstrap-select/.

Attached is one solution.  Another solution is to use keypress instead of keydown.  If you prefer that solution I'm happy to modify PR.

Thanks.
