### PR TITLE
Done trigger event

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -303,6 +303,7 @@
       this.$menu.data('this', this);
       this.$newElement.data('this', this);
       if (this.options.mobile) this.mobile();
+      that.$element.trigger('done');
     },
 
     createDropdown: function () {


### PR DESCRIPTION
If you have a large multiselect it could be heavy to  load and you should hide the unpicked multiselect and then show it. In order to control the timeout it's good to have an event to match the time occurred.
For example: 
$('.selectpicker').on('done', function(){
        $("#loader").fadeOut("slow");
        $("#form").removeClass('hide');
    });
Instead of:
setTimeout(function() {
        $("#loader").fadeOut("slow");
        $("#form").removeClass('hide');
    }, 700);

Thanks
