### PR TITLE
Fix mobile with input-group and JS refactoring.

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -277,9 +277,9 @@
       this.autofocus = this.$element.prop('autofocus');
       this.$newElement = this.createView();
       this.$element.after(this.$newElement);
-      this.$menu = this.$newElement.children('.dropdown-menu');
       this.$button = this.$newElement.children('button');
-      this.$searchbox = this.$newElement.find('input');
+      this.$menu = this.$newElement.children('.dropdown-menu');
+      this.$searchbox = this.$menu.find('input');
 
       if (this.options.dropdownAlignRight)
         this.$menu.addClass('dropdown-menu-right');
@@ -342,7 +342,7 @@
           : '';
       var drop =
           '<div class="btn-group bootstrap-select' + multiple + inputGroup + '">' +
-          '<button type="button" class="btn dropdown-toggle form-control selectpicker" data-toggle="dropdown"' + autofocus + '>' +
+          '<button type="button" class="btn dropdown-toggle form-control" data-toggle="dropdown"' + autofocus + '>' +
           '<span class="filter-option pull-left"></span>&nbsp;' +
           '<span class="caret"></span>' +
           '</button>' +
@@ -350,7 +350,7 @@
           header +
           searchbox +
           actionsbox +
-          '<ul class="dropdown-menu inner selectpicker" role="menu">' +
+          '<ul class="dropdown-menu inner" role="menu">' +
           '</ul>' +
           donebutton +
           '</div>' +
@@ -497,7 +497,7 @@
       }
 
       this.tabIndex();
-      var notDisabled = this.options.hideDisabled ? ':not([disabled])' : '';
+      var notDisabled = this.options.hideDisabled ? ':enabled' : '';
       var selectedItems = this.$element.find('option:selected' + notDisabled).map(function () {
         var $this = $(this);
         var icon = $this.data('icon') && that.options.showIcon ? '<i class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></i> ' : '';
@@ -546,7 +546,7 @@
 
       //strip all html-tags and trim the result
       this.$button.attr('title', $.trim(title.replace(/<[^>]*>?/g, '')));
-      this.$newElement.find('.filter-option').html(title);
+      this.$button.children('.filter-option').html(title);
     },
 
     /**
@@ -575,7 +575,7 @@
 
       var $selectClone = this.$menu.parent().clone().children('.dropdown-toggle').prop('autofocus', false).end().appendTo('body'),
           $menuClone = $selectClone.addClass('open').children('.dropdown-menu'),
-          liHeight = $menuClone.find('li').not('.divider').not('.dropdown-header').filter(':visible').children('a').outerHeight(),
+          liHeight = $menuClone.find('li').not('.divider, .dropdown-header').filter(':visible').children('a').outerHeight(),
           headerHeight = this.options.header ? $menuClone.find('.popover-title').outerHeight() : 0,
           searchHeight = this.options.liveSearch ? $menuClone.find('.bs-searchbox').outerHeight() : 0,
           actionsHeight = this.options.actionsBox ? $menuClone.find('.bs-actionsbox').outerHeight() : 0,
@@ -594,8 +594,8 @@
     setSize: function () {
       this.findLis();
       var that = this,
-          menu = this.$menu,
-          menuInner = menu.find('.inner'),
+          $menu = this.$menu,
+          $menuInner = $menu.children('.inner'),
           selectHeight = this.$newElement.outerHeight(),
           liHeight = this.$newElement.data('liHeight'),
           headerHeight = this.$newElement.data('headerHeight'),
@@ -603,13 +603,13 @@
           actionsHeight = this.$newElement.data('actionsHeight'),
           doneButtonHeight = this.$newElement.data('doneButtonHeight'),
           divHeight = this.$lis.filter('.divider').outerHeight(true),
-          menuPadding = parseInt(menu.css('padding-top')) +
-              parseInt(menu.css('padding-bottom')) +
-              parseInt(menu.css('border-top-width')) +
-              parseInt(menu.css('border-bottom-width')),
-          notDisabled = this.options.hideDisabled ? ', .disabled' : '',
+          menuPadding = parseInt($menu.css('padding-top')) +
+              parseInt($menu.css('padding-bottom')) +
+              parseInt($menu.css('border-top-width')) +
+              parseInt($menu.css('border-bottom-width')),
+          notDisabled = this.options.hideDisabled ? '.disabled' : '',
           $window = $(window),
-          menuExtras = menuPadding + parseInt(menu.css('margin-top')) + parseInt(menu.css('margin-bottom')) + 2,
+          menuExtras = menuPadding + parseInt($menu.css('margin-top')) + parseInt($menu.css('margin-bottom')) + 2,
           menuHeight,
           selectOffsetTop,
           selectOffsetBot,
@@ -620,7 +620,7 @@
             selectOffsetBot = $window.height() - selectOffsetTop - selectHeight;
           };
       posVert();
-      if (this.options.header) menu.css('padding-top', 0);
+      if (this.options.header) $menu.css('padding-top', 0);
 
       if (this.options.size == 'auto') {
         var getSize = function () {
@@ -631,7 +631,7 @@
           menuHeight = selectOffsetBot - menuExtras;
 
           if (that.options.dropupAuto) {
-            that.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && (menuHeight - menuExtras) < menu.height());
+            that.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && (menuHeight - menuExtras) < $menu.height());
           }
           if (that.$newElement.hasClass('dropup')) {
             menuHeight = selectOffsetTop - menuExtras;
@@ -643,12 +643,12 @@
             minHeight = 0;
           }
 
-          menu.css({
+          $menu.css({
             'max-height': menuHeight + 'px',
             'overflow': 'hidden',
             'min-height': minHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px'
           });
-          menuInner.css({
+          $menuInner.css({
             'max-height': menuHeight - headerHeight - searchHeight - actionsHeight - doneButtonHeight - menuPadding + 'px',
             'overflow-y': 'auto',
             'min-height': Math.max(minHeight - menuPadding, 0) + 'px'
@@ -656,21 +656,23 @@
         };
         getSize();
         this.$searchbox.off('input.getSize propertychange.getSize').on('input.getSize propertychange.getSize', getSize);
-        $window.off('resize.getSize').on('resize.getSize', getSize);
-        $window.off('scroll.getSize').on('scroll.getSize', getSize);
-      } else if (this.options.size && this.options.size != 'auto' && menu.find('li' + notDisabled).length > this.options.size) {
-        var optIndex = this.$lis.not('.divider' + notDisabled).children().slice(0, this.options.size).last().parent().index();
+        $window.off('resize.getSize scroll.getSize').on('resize.getSize scroll.getSize', getSize);
+      } else if (this.options.size && this.options.size != 'auto' && $menu.find('li').not(notDisabled).length > this.options.size) {
+        var optIndex = this.$lis.not('.divider').not(notDisabled).children().slice(0, this.options.size).last().parent().index();
         var divLength = this.$lis.slice(0, optIndex + 1).filter('.divider').length;
         menuHeight = liHeight * this.options.size + divLength * divHeight + menuPadding;
         if (that.options.dropupAuto) {
           //noinspection JSUnusedAssignment
-          this.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && menuHeight < menu.height());
+          this.$newElement.toggleClass('dropup', selectOffsetTop > selectOffsetBot && menuHeight < $menu.height());
         }
-        menu.css({
+        $menu.css({
           'max-height': menuHeight + headerHeight + searchHeight + actionsHeight + doneButtonHeight + 'px',
           'overflow': 'hidden'
         });
-        menuInner.css({'max-height': menuHeight - menuPadding + 'px', 'overflow-y': 'auto'});
+        $menuInner.css({
+          'max-height': menuHeight - menuPadding + 'px',
+          'overflow-y': 'auto'
+        });
       }
     },
 
@@ -731,10 +733,7 @@
         $drop.toggleClass('open', !$(this).hasClass('open'));
         $drop.append(that.$menu);
       });
-      $(window).resize(function () {
-        getPlacement(that.$newElement);
-      });
-      $(window).on('scroll', function () {
+      $(window).on('resize scroll', function () {
         getPlacement(that.$newElement);
       });
       $('html').on('click', function (e) {
@@ -752,9 +751,9 @@
     setDisabled: function (index, disabled) {
       this.findLis();
       if (disabled) {
-        this.$lis.filter('[data-original-index="' + index + '"]').addClass('disabled').find('a').attr('href', '#').attr('tabindex', -1);
+        this.$lis.filter('[data-original-index="' + index + '"]').addClass('disabled').children('a').attr('href', '#').attr('tabindex', -1);
       } else {
-        this.$lis.filter('[data-original-index="' + index + '"]').removeClass('disabled').find('a').removeAttr('href').attr('tabindex', 0);
+        this.$lis.filter('[data-original-index="' + index + '"]').removeClass('disabled').children('a').removeAttr('href').attr('tabindex', 0);
       }
     },
 
@@ -772,8 +771,8 @@
           this.$button.removeClass('disabled');
         }
 
-        if (this.$button.attr('tabindex') == -1) {
-          if (!this.$element.data('tabindex')) this.$button.removeAttr('tabindex');
+        if (this.$button.attr('tabindex') == -1 && !this.$element.data('tabindex')) {
+          this.$button.removeAttr('tabindex');
         }
       }
 
@@ -911,10 +910,10 @@
         if (e.currentTarget == this) {
           e.preventDefault();
           e.stopPropagation();
-          if (!that.options.liveSearch) {
-            that.$button.focus();
-          } else {
+          if (that.options.liveSearch) {
             that.$searchbox.focus();
+          } else {
+            that.$button.focus();
           }
         }
       });
@@ -922,10 +921,10 @@
       this.$menu.on('click', 'li.divider, li.dropdown-header', function (e) {
         e.preventDefault();
         e.stopPropagation();
-        if (!that.options.liveSearch) {
-          that.$button.focus();
-        } else {
+        if (that.options.liveSearch) {
           that.$searchbox.focus();
+        } else {
+          that.$button.focus();
         }
       });
 
@@ -937,7 +936,6 @@
         e.stopPropagation();
       });
 
-
       this.$menu.on('click', '.actions-btn', function (e) {
         if (that.options.liveSearch) {
           that.$searchbox.focus();
@@ -948,7 +946,7 @@
         e.preventDefault();
         e.stopPropagation();
 
-        if ($(this).is('.bs-select-all')) {
+        if ($(this).hasClass('bs-select-all')) {
           that.selectAll();
         } else {
           that.deselectAll();
@@ -963,14 +961,14 @@
 
     liveSearchListener: function () {
       var that = this,
-          no_results = $('<li class="no-results"></li>');
+          $no_results = $('<li class="no-results"></li>');
 
       this.$newElement.on('click.dropdown.data-api touchstart.dropdown.data-api', function () {
         that.$menu.find('.active').removeClass('active');
         if (!!that.$searchbox.val()) {
           that.$searchbox.val('');
           that.$lis.not('.is-hidden').removeClass('hidden');
-          if (!!no_results.parent().length) no_results.remove();
+          if (!!$no_results.parent().length) $no_results.remove();
         }
         if (!that.multiple) that.$menu.find('.selected').addClass('active');
         setTimeout(function () {
@@ -984,7 +982,7 @@
 
       this.$searchbox.on('input propertychange', function () {
         if (that.$searchbox.val()) {
-          var $searchBase = that.$lis.not('.is-hidden').removeClass('hidden').find('a');
+          var $searchBase = that.$lis.not('.is-hidden').removeClass('hidden').children('a');
           if (that.options.liveSearchNormalize) {
             $searchBase = $searchBase.not(':a' + that._searchStyle() + '(' + normalizeToBase(that.$searchbox.val()) + ')');
           } else {
@@ -1006,36 +1004,35 @@
 
           // hide divider if first or last visible, or if followed by another divider
           $lisVisible.each(function(index) {
-              var $this = $(this);
-              
-              if ($this.is('.divider')) {
-                  if ($this.index() === $lisVisible.eq(0).index() || 
-                      $this.index() === $lisVisible.last().index() ||
-                      $lisVisible.eq(index + 1).is('.divider')) {
-                      $this.addClass('hidden');
-                  }
-              }
+            var $this = $(this);
+
+            if ($this.hasClass('divider') && (
+              $this.index() === $lisVisible.eq(0).index() ||
+              $this.index() === $lisVisible.last().index() ||
+              $lisVisible.eq(index + 1).hasClass('divider'))) {
+              $this.addClass('hidden');
+            }
           });
 
-          if (!that.$lis.filter(':not(.hidden):not(.no-results)').length) {
-            if (!!no_results.parent().length) {
-              no_results.remove();
+          if (!that.$lis.not('.hidden, .no-results').length) {
+            if (!!$no_results.parent().length) {
+              $no_results.remove();
             }
-            no_results.html(that.options.noneResultsText.replace('{0}', '"' + htmlEscape(that.$searchbox.val()) + '"')).show();
-            that.$menu.find('li').last().after(no_results);
-          } else if (!!no_results.parent().length) {
-            no_results.remove();
+            $no_results.html(that.options.noneResultsText.replace('{0}', '"' + htmlEscape(that.$searchbox.val()) + '"')).show();
+            that.$menu.append($no_results);
+          } else if (!!$no_results.parent().length) {
+            $no_results.remove();
           }
 
         } else {
           that.$lis.not('.is-hidden').removeClass('hidden');
-          if (!!no_results.parent().length) {
-            no_results.remove();
+          if (!!$no_results.parent().length) {
+            $no_results.remove();
           }
         }
 
         that.$lis.filter('.active').removeClass('active');
-        that.$lis.filter(':not(.hidden):not(.divider):not(.dropdown-header)').eq(0).addClass('active').find('a').focus();
+        that.$lis.not('.hidden, .divider, .dropdown-header').eq(0).addClass('active').children('a').focus();
         $(this).focus();
       });
     },
@@ -1068,21 +1065,21 @@
 
     selectAll: function () {
       this.findLis();
-      this.$element.find('option:enabled').not('[data-divider]').not('[data-hidden]').prop('selected', true);
-      this.$lis.not('.divider').not('.dropdown-header').not('.disabled').not('.hidden').addClass('selected');
+      this.$element.find('option:enabled').not('[data-divider], [data-hidden]').prop('selected', true);
+      this.$lis.not('.divider, .dropdown-header, .disabled, .hidden').addClass('selected');
       this.render(false);
     },
 
     deselectAll: function () {
       this.findLis();
-      this.$element.find('option:enabled').not('[data-divider]').not('[data-hidden]').prop('selected', false);
-      this.$lis.not('.divider').not('.dropdown-header').not('.disabled').not('.hidden').removeClass('selected');
+      this.$element.find('option:enabled').not('[data-divider], [data-hidden]').prop('selected', false);
+      this.$lis.not('.divider, .dropdown-header, .disabled, .hidden').removeClass('selected');
       this.render(false);
     },
 
     keydown: function (e) {
       var $this = $(this),
-          $parent = ($this.is('input')) ? $this.parent().parent() : $this.parent(),
+          $parent = $this.is('input') ? $this.parent().parent() : $this.parent(),
           $items,
           that = $parent.data('this'),
           index,
@@ -1194,7 +1191,7 @@
 
         if (that.options.liveSearch) {
           $items.each(function (i) {
-            if ($(this).is(':not(.disabled)')) {
+            if (!$(this).hasClass('disabled')) {
               $(this).data('index', i);
             }
           });
@@ -1213,9 +1210,7 @@
           if (index != nextPrev && index > prev) index = prev;
           if (index < first) index = first;
           if (index == prevIndex) index = last;
-        }
-
-        if (e.keyCode == 40) {
+        } else if (e.keyCode == 40) {
           if (that.options.liveSearch) index += 1;
           if (index == -1) index = 0;
           if (index != nextPrev && index < next) index = next;
@@ -1229,9 +1224,9 @@
           $items.eq(index).focus();
         } else {
           e.preventDefault();
-          if (!$this.is('.dropdown-toggle')) {
+          if (!$this.hasClass('dropdown-toggle')) {
             $items.removeClass('active');
-            $items.eq(index).addClass('active').find('a').focus();
+            $items.eq(index).addClass('active').children('a').focus();
             $this.focus();
           }
         }
@@ -1242,7 +1237,7 @@
             prevKey;
 
         $items.each(function () {
-          if ($(this).parent().is(':not(.disabled)')) {
+          if (!$(this).parent().hasClass('disabled')) {
             if ($.trim($(this).text().toLowerCase()).substring(0, 1) == keyCodeMap[e.keyCode]) {
               keyIndex.push($(this).parent().index());
             }

--- a/js/i18n/defaults-ru_RU.js
+++ b/js/i18n/defaults-ru_RU.js
@@ -9,6 +9,7 @@
     noneResultsText: 'Совпадений не найдено {0}',
     countSelectedText: 'Выбрано {0} из {1}',
     maxOptionsText: ['Достигнут предел ({n} {var} максимум)', 'Достигнут предел в группе ({n} {var} максимум)', ['items', 'item']],
+    doneButtonText: 'Закрыть',
     multipleSeparator: ', '
   };
 })(jQuery);

--- a/less/bootstrap-select.less
+++ b/less/bootstrap-select.less
@@ -44,6 +44,10 @@
   &:not([class*="col-"]) {
     width: 100%;
   }
+
+  &.input-group-btn {
+    z-index: auto;
+  }
 }
 
 // The selectpicker components
@@ -58,7 +62,7 @@
   // Forces the pull to the right, if necessary
   &,
   &[class*="col-"],
-  .row-fluid &[class*="col-"] {
+  .row &[class*="col-"] {
     &.dropdown-menu-right {
       float: right;
     }
@@ -129,10 +133,8 @@
     li {
       position: relative;
 
-      &:not(.disabled) a:hover small,
-      &:not(.disabled) a:focus small,
-      &.active:not(.disabled) a small {
-        color: @color-blue-hover;
+      &.active small {
+        color: #fff;
       }
 
       &.disabled a {
@@ -150,6 +152,7 @@
         span.check-mark {
           display: none;
         }
+
         span.text {
           display: inline-block;
         }
@@ -311,7 +314,7 @@
 }
 
 .mobile-device {
-  position: absolute;
+  position: absolute !important;
   top: 0;
   left: 0;
   display: block !important;

--- a/less/variables.less
+++ b/less/variables.less
@@ -1,5 +1,4 @@
 @color-red-error: rgb(185, 74, 72);
-@color-blue-hover: rgba(100, 177, 216, 0.4);
 @color-grey-arrow: rgba(204, 204, 204, 0.2);
 
 @width-default: 220px; // 3 960px-grid columns

--- a/test.html
+++ b/test.html
@@ -5,8 +5,8 @@
 
   <meta charset="utf-8">
 
-  <link rel="stylesheet" type="text/css" href="dist/css/bootstrap-select.css">
-  <link href="//netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css" rel="stylesheet">
+  <link rel="stylesheet" href="//netdna.bootstrapcdn.com/bootstrap/3.2.0/css/bootstrap.min.css">
+  <link rel="stylesheet" href="dist/css/bootstrap-select.css">
 
   <style>
     body {
@@ -14,9 +14,9 @@
     }
   </style>
 
-  <script type="text/javascript" src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
-  <script type="text/javascript" src="dist/js/bootstrap-select.js"></script>
+  <script src="//ajax.googleapis.com/ajax/libs/jquery/1.10.1/jquery.min.js"></script>
   <script src="//netdna.bootstrapcdn.com/bootstrap/3.2.0/js/bootstrap.min.js"></script>
+  <script src="dist/js/bootstrap-select.js"></script>
 </head>
 <body>
 <nav class="navbar navbar-default navbar-fixed-top" role="navigation">
@@ -35,9 +35,9 @@
       <div class="col-lg-10">
         <select id="basic" class="selectpicker show-tick form-control" data-live-search="true">
           <option>cow</option>
-          <option>bull</option>
+          <option data-subtext="option subtext">bull</option>
           <option class="get-class" disabled>ox</option>
-          <optgroup label="test" data-subtext="another test">
+          <optgroup label="test" data-subtext="optgroup subtext">
             <option>ASD</option>
             <option selected>Bla</option>
             <option>Ble</option>
@@ -50,7 +50,7 @@
   <hr>
   <form class="form-horizontal" role="form">
     <div class="form-group">
-      <label for="basic2" class="col-lg-2 control-label">"Basic" #2 (multiple max-option=1)</label>
+      <label for="basic2" class="col-lg-2 control-label">"Basic" #2 (multiple, max-option=1)</label>
 
       <div class="col-lg-10">
         <select id="basic2" class="show-tick form-control" multiple>
@@ -70,7 +70,7 @@
   <hr>
   <form class="form-horizontal" role="form">
     <div class="form-group">
-      <label for="maxOption2" class="col-lg-2 control-label">multiple, show-menu-arrow, & max-option = 2</label>
+      <label for="maxOption2" class="col-lg-2 control-label">multiple, show-menu-arrow, max-option=2</label>
 
       <div class="col-lg-10">
         <select id="maxOption2" class="selectpicker show-menu-arrow form-control" multiple data-max-options="2">
@@ -86,7 +86,7 @@
   <hr>
   <form class="form-inline">
     <div class="form-group">
-      <label class="col-md-1 control-label" for="lunch">Lunch: </label>
+      <label class="col-md-1 control-label" for="lunch">Lunch:</label>
     </div>
     <div class="form-group">
       <select id="lunch" class="selectpicker" data-live-search="true" title="Please select a lunch ...">
@@ -221,6 +221,17 @@
   </div>
 
   <hr>
+  <div class="input-group">
+    <span class="input-group-addon">@</span>
+    <select class="form-control selectpicker" data-mobile="true">
+      <option>One</option>
+      <option>Two</option>
+      <option>Three</option>
+    </select>
+  </div>
+  <p>With <code>data-mobile="true"</code> option.</p>
+
+  <hr>
   <select id="done" class="selectpicker" multiple data-done-button="true">
     <option>Apple</option>
     <option>Banana</option>
@@ -246,7 +257,7 @@
   <hr>
   <form class="form-inline">
     <div class="form-group">
-      <label class="col-md-1 control-label" for="lunch">Lunch (Begins search): </label>
+      <label class="col-md-1 control-label" for="lunchBegins">Lunch (Begins search):</label>
     </div>
     <div class="form-group">
       <select id="lunchBegins" class="selectpicker" data-live-search="true" data-live-search-style="begins" title="Please select a lunch ...">
@@ -258,7 +269,6 @@
       </select>
     </div>
   </form>
-  
 </div>
 
 <script>
@@ -269,12 +279,13 @@
       mySelect.find('option:selected').prop('disabled', true);
       mySelect.selectpicker('refresh');
     });
+
     $('#special2').on('click', function () {
       mySelect.find('option:disabled').prop('disabled', false);
       mySelect.selectpicker('refresh');
     });
 
-    var $basic2 = $('#basic2').selectpicker({
+    $('#basic2').selectpicker({
       liveSearch: true,
       maxOptions: 1
     });


### PR DESCRIPTION
1. This styles in Bootstrap 3 overwrite `.mobile-device` `position` option:

``` css
.input-group .form-control {
  position: relative;
}
```

Added visual test.
1. `.row-fluid` changed to `.row`: http://getbootstrap.com/migration/
2. Fix z-index: http://jsbin.com/foripenovi/2/edit?html,css,output
   - Section "Before": open dropdown 1.
   - Section "After": open dropdown 1.
3. `:enabled` == `:not([disabled])` http://api.jquery.com/enabled-selector/
4. http://jsperf.com/jquery-hasclass-vs-is-performance/2
5. Fix notDisabled. `.not('')` skipped. (works correctly for `.not(notDisabled)`)
6. Change jQuery elements `menu`, `menuInner`, `no_results` to `$menu`, `$menuInner`, `$no_results`
7. Some refactoring JavaScript and speed improvement
8. Fix `option` subtext styles on hover and activation, add visual test.
9. Removed not used (not needed) `selectpicker` class on `this.$button` and `this.$menu`
10. `that.$menu.find('li').last().after(no_results)` changed to `that.$menu.append($no_results)`
