### PR TITLE
Added support for locale option

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ bower_components
 
 # Dist zip
 bootstrap-select-*.zip
+/nbproject/private/

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -215,6 +215,7 @@
     this.remove = Selectpicker.prototype.remove;
     this.show = Selectpicker.prototype.show;
     this.hide = Selectpicker.prototype.hide;
+    this.locale = Selectpicker.prototype.locale;
 
     this.init();
   };
@@ -263,6 +264,60 @@
     selectOnTab: false,
     dropdownAlignRight: false
   };
+  
+  var Locales = {
+      
+      _locales: {},
+      
+      normalize: function (key) {
+          return key ? key.toLowerCase().replace('_', '-') : key;
+      },
+      
+      add: function (name, values) {
+        var key = this.normalize(name);
+        if (values !== null) {
+          this._locales[key] = values;
+        } else {
+          delete this._locales[key];
+        }
+      },
+      
+      get: function (name) {
+        var key = this.normalize(name);
+        return this._locales[key];
+      },
+      
+      _isArray: function(input) {
+        return Object.prototype.toString.call(input) === '[object Array]';
+      },
+      
+      choose: function (names) {
+        var i = 0, j, next, locale, split;
+        
+        if (!this._isArray(names))
+          names = [names];
+
+        while (i < names.length) {
+            split = this.normalize(names[i]).split('-');
+            j = split.length;
+            next = this.normalize(names[i + 1]);
+            next = next ? next.split('-') : null;
+            while (j > 0) {
+                locale = this.get(split.slice(0, j).join('-'));
+                if (locale) {
+                    return locale;
+                }
+                if (next && next.length >= j && compareArrays(split, next, true) >= j - 1) {
+                    //the next array item is better than a shallower substring of this one
+                    break;
+                }
+                j--;
+            }
+            i++;
+        }
+        return null;
+    }
+  };
 
   Selectpicker.prototype = {
 
@@ -271,6 +326,9 @@
     init: function () {
       var that = this,
           id = this.$element.attr('id');
+  
+      if (this.options.locale)
+        this.locale(this.options.locale);
 
       this.$element.hide();
       this.multiple = this.$element.prop('multiple');
@@ -303,6 +361,17 @@
       this.$menu.data('this', this);
       this.$newElement.data('this', this);
       if (this.options.mobile) this.mobile();
+    },
+    
+    locale: function (name) {
+        var data;
+        if (name) {
+            data = Locales.choose(name);
+
+            if (data) {
+                this.options = $.extend({}, this.options, data);
+            }
+        }
     },
 
     createDropdown: function () {
@@ -1332,7 +1401,7 @@
             options = typeof _option == 'object' && _option;
 
         if (!data) {
-          var config = $.extend({}, Selectpicker.DEFAULTS, $.fn.selectpicker.defaults || {}, $this.data(), options);
+          var config = $.extend({}, Selectpicker.DEFAULTS, $this.data(), options);
           $this.data('selectpicker', (data = new Selectpicker(this, config, _event)));
         } else if (options) {
           for (var i in options) {
@@ -1363,6 +1432,7 @@
   var old = $.fn.selectpicker;
   $.fn.selectpicker = Plugin;
   $.fn.selectpicker.Constructor = Selectpicker;
+  $.fn.selectpicker.locales = Locales;
 
   // SELECTPICKER NO CONFLICT
   // ========================

--- a/js/i18n/defaults-bg_BG.js
+++ b/js/i18n/defaults-bg_BG.js
@@ -4,7 +4,7 @@
  * Region: BG (Bulgaria)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('bg_BG', {
     noneSelectedText: 'Нищо избрано',
     noneResultsText: 'Няма резултат за {0}',
     countSelectedText: function (numSelected, numTotal) {
@@ -19,5 +19,5 @@
     selectAllText: 'Избери всички',
     deselectAllText: 'Размаркирай всички',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-cs_CZ.js
+++ b/js/i18n/defaults-cs_CZ.js
@@ -4,11 +4,11 @@
  * Region: CZ (Czech Republic)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('cs_CZ', {
     noneSelectedText: 'Nic není vybráno',
     noneResultsText: 'Žádné výsledky {0}',
     countSelectedText: 'Označeno {0} z {1}',
     maxOptionsText: ['Limit překročen ({n} {var} max)', 'Limit skupiny překročen ({n} {var} max)', ['položek', 'položka']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-de_DE.js
+++ b/js/i18n/defaults-de_DE.js
@@ -4,11 +4,11 @@
  * Region: DE (Germany, Deutschland)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('de_DE', {
     noneSelectedText: 'Bitte wählen...',
     noneResultsText: 'Keine Ergebnisse für {0}',
     countSelectedText: '{0} von {1} ausgewählt',
     maxOptionsText: ['Limit erreicht ({n} {var} max.)', 'Gruppen-Limit erreicht ({n} {var} max.)', ['Eintrag', 'Einträge']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-en_US.js
+++ b/js/i18n/defaults-en_US.js
@@ -4,7 +4,7 @@
  * Region: US (United States)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('en_US', {
     noneSelectedText: 'Nothing selected',
     noneResultsText: 'No results match {0}',
     countSelectedText: function (numSelected, numTotal) {
@@ -19,5 +19,5 @@
     selectAllText: 'Select All',
     deselectAllText: 'Deselect All',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-es_CL.js
+++ b/js/i18n/defaults-es_CL.js
@@ -4,11 +4,11 @@
  * Region: CL (Chile)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('es_CL', {
     noneSelectedText: 'No hay selección',
     noneResultsText: 'No hay resultados {0}',
     countSelectedText: 'Seleccionados {0} de {1}',
     maxOptionsText: ['Límite alcanzado ({n} {var} max)', 'Límite del grupo alcanzado({n} {var} max)', ['elementos', 'element']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-eu.js
+++ b/js/i18n/defaults-eu.js
@@ -4,11 +4,11 @@
  * Region: 
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('eu', {
     noneSelectedText: 'Hautapenik ez',
     noneResultsText: 'Emaitzarik ez {0}',
     countSelectedText: '{1}(e)tik {0} hautatuta',
     maxOptionsText: ['Mugara iritsita ({n} {var} gehienez)', 'Taldearen mugara iritsita ({n} {var} gehienez)', ['elementu', 'elementu']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-fr_FR.js
+++ b/js/i18n/defaults-fr_FR.js
@@ -4,7 +4,7 @@
  * Region: FR (France)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('fr_FR', {
     noneSelectedText: 'Aucune s&eacute;lection',
     noneResultsText: 'Aucun r&eacute;sultat pour {0}',
     countSelectedText: function (numSelected, numTotal) {
@@ -17,5 +17,5 @@
       ];
     },
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-hu_HU.js
+++ b/js/i18n/defaults-hu_HU.js
@@ -4,7 +4,7 @@
  * Region: HU (Hungary)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('hu_HU', {
     noneSelectedText: 'Válasszon!',
     noneResultsText: 'Nincs találat {0}',
     countSelectedText: function (numSelected, numTotal) {
@@ -19,5 +19,5 @@
     selectAllText: 'Mind',
     deselectAllText: 'Egyik sem',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-it_IT.js
+++ b/js/i18n/defaults-it_IT.js
@@ -5,11 +5,11 @@
  * Author: Michele Beltrame <mb@cattlegrid.info>
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('it_IT', {
     noneSelectedText: 'Nessuna selezione',
     noneResultsText: 'Nessun risultato per {0}',
     countSelectedText: 'Selezionati {0} di {1}',
     maxOptionsText: ['Limite raggiunto ({n} {var} max)', 'Limite del gruppo raggiunto ({n} {var} max)', ['elementi', 'elemento']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-nl_NL.js
+++ b/js/i18n/defaults-nl_NL.js
@@ -5,11 +5,11 @@
  * Author: Daan Rosbergen (Badmuts)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('nl_NL', {
     noneSelectedText: 'Niets geselecteerd',
     noneResultsText: 'Geen resultaten gevonden voor {0}',
     countSelectedText: '{0} van {1} geselecteerd',
     maxOptionsText: ['Limiet bereikt ({n} {var} max)', 'Groep limiet bereikt ({n} {var} max)', ['items', 'item']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-pl_PL.js
+++ b/js/i18n/defaults-pl_PL.js
@@ -4,7 +4,7 @@
  * Region: EU (Europe)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('pl_PL', {
     noneSelectedText: 'Nic nie zaznaczono',
     noneResultsText: 'Brak wyników wyszukiwania {0}',
     countSelectedText: 'Zaznaczono {0} z {1}',
@@ -12,5 +12,5 @@
     selectAll: 'Zaznacz wszystkie',
     deselectAll: 'Odznacz wszystkie',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-pt_BR.js
+++ b/js/i18n/defaults-pt_BR.js
@@ -5,11 +5,11 @@
  * Author: Rodrigo de Avila <rodrigo@avila.net.br>
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('pt_BR', {
     noneSelectedText: 'Nada selecionado',
     noneResultsText: 'Nada encontrado contendo {0}',
     countSelectedText: 'Selecionado {0} de {1}',
     maxOptionsText: ['Limite excedido (máx. {n} {var})', 'Limite do grupo excedido (máx. {n} {var})', ['itens', 'item']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-ro_RO.js
+++ b/js/i18n/defaults-ro_RO.js
@@ -5,11 +5,11 @@
  * Alex Florea <alecz.fia@gmail.com>
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('ro_RO', {
     noneSelectedText: 'Nu a fost selectat nimic',
     noneResultsText: 'Nu exista niciun rezultat {0}',
     countSelectedText: '{0} din {1} selectat(e)',
     maxOptionsText: ['Limita a fost atinsa ({n} {var} max)', 'Limita de grup a fost atinsa ({n} {var} max)', ['iteme', 'item']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-ru_RU.js
+++ b/js/i18n/defaults-ru_RU.js
@@ -4,12 +4,12 @@
  * Region: RU (Russian Federation)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('ru_RU', {
     noneSelectedText: 'Ничего не выбрано',
     noneResultsText: 'Совпадений не найдено {0}',
     countSelectedText: 'Выбрано {0} из {1}',
     maxOptionsText: ['Достигнут предел ({n} {var} максимум)', 'Достигнут предел в группе ({n} {var} максимум)', ['items', 'item']],
     doneButtonText: 'Закрыть',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-sl_SI.js
+++ b/js/i18n/defaults-sl_SI.js
@@ -4,7 +4,7 @@
  * Region: SI (Slovenia)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('sl_SL', {
     noneSelectedText: 'Nič izbranega',
     noneResultsText: 'Ni zadetkov za {0}',
     countSelectedText: function (numSelected, numTotal) {
@@ -19,5 +19,5 @@
     selectAllText: 'Izberi vse',
     deselectAllText: 'Počisti izbor',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-sv_SE.js
+++ b/js/i18n/defaults-sv_SE.js
@@ -4,7 +4,7 @@
  * Region: SE (Sweden)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('sv_SE', {
     noneSelectedText: 'Inget valt',
     noneResultsText: 'Inget sökresultat matchar {0}',
     countSelectedText: function (numSelected, numTotal) {
@@ -19,5 +19,5 @@
     selectAllText: 'Markera alla',
     deselectAllText: 'Avmarkera alla',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-tr_TR.js
+++ b/js/i18n/defaults-tr_TR.js
@@ -5,7 +5,7 @@
  * Author: Serhan Güney
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('tr_TR', {
     noneSelectedText: 'Hiçbiri seçilmedi',
     noneResultsText: 'Hiçbir sonuç bulunamadı {0}',
     countSelectedText: function (numSelected, numTotal) {
@@ -20,5 +20,5 @@
     selectAllText: 'Tümünü Seç',
     deselectAllText: 'Seçiniz',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-ua_UA.js
+++ b/js/i18n/defaults-ua_UA.js
@@ -4,11 +4,11 @@
  * Region: UA (Ukraine)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('ua_UA', {
     noneSelectedText: 'Нічого не вибрано',
     noneResultsText: 'Збігів не знайдено {0}',
     countSelectedText: 'Вибрано {0} із {1}',
     maxOptionsText: ['Досягнута межа ({n} {var} максимум)', 'Досягнута межа в групі ({n} {var} максимум)', ['items', 'item']],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-zh_CN.js
+++ b/js/i18n/defaults-zh_CN.js
@@ -4,11 +4,11 @@
  * Region: CN (China)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('zh_CN', {
     noneSelectedText: '没有选中任何项',
     noneResultsText: '没有找到匹配项',
     countSelectedText: '选中{1}中的{0}项',
     maxOptionsText: ['超出限制 (最多选择{n}项)', '组选择超出限制(最多选择{n}组)'],
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);

--- a/js/i18n/defaults-zh_TW.js
+++ b/js/i18n/defaults-zh_TW.js
@@ -4,7 +4,7 @@
  * Region: TW (Taiwan)
  */
 (function ($) {
-  $.fn.selectpicker.defaults = {
+  $.fn.selectpicker.locales.add('zh_TW', {
     noneSelectedText: '沒有選取任何項目',
     noneResultsText: '沒有找到符合的結果',
     countSelectedText: '已經選取{0}個項目',
@@ -12,5 +12,5 @@
     selectAllText: '選取全部',
     deselectAllText: '全部取消',
     multipleSeparator: ', '
-  };
+  });
 })(jQuery);


### PR DESCRIPTION
I have made some modifications to the code to allow for a `data-local` attribute and a `locale` method. This enables users to combine all locale files into a single file. This way we don't need to perform any special handling server side. If a locale is not found it will default to the built in 'en_US' or the last used locale. Also, given an array of locales, it will try to find the best, i.e. [en_GB, en_US] if neither are found it will try 'en'.

The one problem I cannot seem to work around is the BC. This approach requires the locale to be specified and the inclusion of a single locale file after loading selectpicker no longer works. 
