### PR TITLE
Added an expanded option

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -303,7 +303,7 @@
       this.$menu.data('this', this);
       this.$newElement.data('this', this);
       if (this.options.mobile) this.mobile();
-      if (this.options.expanded) this.expanded();
+      else if (this.options.expanded) this.expanded();
     },
 
     createDropdown: function () {

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -303,6 +303,7 @@
       this.$menu.data('this', this);
       this.$newElement.data('this', this);
       if (this.options.mobile) this.mobile();
+      if (this.options.expanded) this.expanded();
     },
 
     createDropdown: function () {
@@ -1287,6 +1288,10 @@
     mobile: function () {
       this.$element.addClass('mobile-device').appendTo(this.$newElement);
       if (this.options.container) this.$menu.hide();
+    },
+    
+    expanded: function () {
+        this.$newElement.addClass('expanded');
     },
 
     refresh: function () {

--- a/less/bootstrap-select.less
+++ b/less/bootstrap-select.less
@@ -276,6 +276,22 @@
   }
 }
 
+.bootstrap-select.expanded {
+  height: auto;
+  
+  .dropdown-toggle {
+    display: none;
+  }
+  
+  .dropdown-menu {
+    display: block;
+    position: relative;
+    box-shadow: none;
+    margin: 0;
+    z-index: auto;
+  }
+}
+
 .bs-searchbox,
 .bs-actionsbox,
 .bs-donebutton {


### PR DESCRIPTION
I have added this option to make the control play nice with Symfony forms. Symfony has a form type called 'choice', a synonym for select, which has an option called expanded. When this option is given, rather than outputting a standard select control, it will render an unordered list where each option is replaced with either a checkbox or radio, depending on the multiple attribute.

This added option simply adds an 'expanded' class to the new element. It hides the button and makes the list always visible. The functionality has not been changed.

If you know Symfony, you would also know that to produce the same effect would require creating a form theme and wrapping the existing control in a div so that the css class can be applied to the new child. Now, we just need to add an extra parameter to the form builder.
