### PR TITLE
Add main declaration to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,6 +39,7 @@
     "type": "MIT",
     "url": "https://github.com/silviomoreto/bootstrap-select/blob/master/LICENSE"
   },
+  "main": "./js/bootstrap-select",
   "dependencies": {
     "jquery": ">=1.8"
   },


### PR DESCRIPTION
Added main declaration pointing to bootstrap-select entry point to allow bundling via browserify. This will enable the common [vendor browserify recipe](https://github.com/sogko/gulp-recipes/blob/master/browserify-separating-app-and-vendor-bundles/gulpfile.js).
