### PR TITLE
Clicked option passed on change plus option click event

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -906,7 +906,7 @@
           }
 
           // Trigger click event on the option
-          $option.click();
+          $option.triggerHandler('click');
         }
       });
 

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -902,7 +902,7 @@
           // Trigger select 'change'
           if ((prevValue != that.$element.val() && that.multiple) || (prevIndex != that.$element.prop('selectedIndex') && !that.multiple)) {
             // pass the recently clicked option, useful for select multiple and validation purposes
-            that.$element.trigger("change", $option);
+            that.$element.trigger('change', $option);
           }
 
           // Trigger click event on the option

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -901,8 +901,12 @@
 
           // Trigger select 'change'
           if ((prevValue != that.$element.val() && that.multiple) || (prevIndex != that.$element.prop('selectedIndex') && !that.multiple)) {
-            that.$element.change();
+            // pass the recently clicked option, useful for select multiple and validation purposes
+            that.$element.trigger("change", $option);
           }
+
+          // Trigger click event on the option
+          $option.click();
         }
       });
 


### PR DESCRIPTION
Selected option will be passed as extra data to the change event function. In addition the option click event will be triggered as well in case there are listener for that option. Useful for validations.

Example: Have to disable/enable certain options depending on the selected one, either by adding a click listener to one option or using the second parameter in the change event should be easier to test and validate what other options should be disabled or enabled. 
