### PR TITLE
Fixed a few typos, added label class

### DIFF
--- a/index.html
+++ b/index.html
@@ -389,9 +389,9 @@ that all items can be processed with php,... This is the same for <code>&lt;sele
 
 <p>The supported values are:</p>
 <ul>
-  <li><code>values</code> A comma delimted list of selected values. (default)</li>
+  <li><code>values</code> A comma delimited list of selected values. (default)</li>
   <li><code>count</code> If one item is selected, then the value is shown, if more than one is selected then the
-    number of selected items is displayed, eg <span class="label">2 of 6 selected</span></li>
+    number of selected items is displayed, e.g. <span class="label">2 of 6 selected</span></li>
   <li><code>count > x</code> Where X is the number of items selected when the display format changes from
     <code>values</code> to <code>count</code></li>
 </ul>
@@ -661,7 +661,7 @@ that all items can be processed with php,... This is the same for <code>&lt;sele
 
 <p id="size">The <code>size</code> option is set to <code>'auto'</code> by default. When <code>size</code> is set to
   <code>'auto'</code>, the menu always opens up to show as many items as the window will allow without being cut off.
-  Set <code>size</code> to <code>false</code> to always show all items. The size of the menu can also be specifed
+  Set <code>size</code> to <code>false</code> to always show all items. The size of the menu can also be specified
   using the <code>data-size</code> attribute.</p>
 
 <div class="bs-docs-example">
@@ -1114,7 +1114,7 @@ Note: this is the same as:<br>
 <h3 id="render">render()</h3>
 
 <p>You can force a re-render of the bootstrap-select ui with the <code>render</code> method. This is useful if you
-  programatically change any underlying values that affect the layout of the element.</p>
+  programmatically change any underlying values that affect the layout of the element.</p>
 
 <pre class="prettyprint linenums">
    $('.selectpicker').selectpicker('render');

--- a/stylesheets/stylesheet.css
+++ b/stylesheets/stylesheet.css
@@ -433,3 +433,8 @@ header.inner h2 {
 .carbonad {
   border-width: 0;
 }
+
+.label {
+	color: black;
+	font-weight: bold;
+}


### PR DESCRIPTION
Thanks for the great library!

I've fixed a few typos in the github pages index, and also added a class for `label`, as it was defaulting to white and was hard to read. 

![screen shot 2015-03-31 at 1 46 52 pm](https://cloud.githubusercontent.com/assets/197404/6929012/89dad9ac-d7ac-11e4-9674-816aa1d8491f.png)

Hope this helps!
