### PR TITLE
Add type="button" prop to actionbox buttons. 

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -339,10 +339,10 @@
       var actionsbox = this.multiple && this.options.actionsBox ?
       '<div class="bs-actionsbox">' +
       '<div class="btn-group btn-group-sm btn-block">' +
-      '<button class="actions-btn bs-select-all btn btn-default">' +
+      '<button type="button" class="actions-btn bs-select-all btn btn-default">' +
       this.options.selectAllText +
       '</button>' +
-      '<button class="actions-btn bs-deselect-all btn btn-default">' +
+      '<button type="button" class="actions-btn bs-deselect-all btn btn-default">' +
       this.options.deselectAllText +
       '</button>' +
       '</div>' +
@@ -351,7 +351,7 @@
       var donebutton = this.multiple && this.options.doneButton ?
       '<div class="bs-donebutton">' +
       '<div class="btn-group btn-block">' +
-      '<button class="btn btn-sm btn-default">' +
+      '<button type="button" class="btn btn-sm btn-default">' +
       this.options.doneButtonText +
       '</button>' +
       '</div>' +


### PR DESCRIPTION
When bootstrap-select is using inside a form an Enter key event triggers clicks over all button elements inside form without type="button" property including buttons of actionbox, causing, for example, the reset of selected value.
