### PR TITLE
Enhanced selected option detection to fix default title in IE8

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -502,7 +502,7 @@
           titleOption.value = '';
           element.insertBefore(titleOption, element.firstChild);
           // Check if selected attribute is already set on an option. If not, select the titleOption option.
-          if (element.options[element.selectedIndex].getAttribute('selected') === null) titleOption.selected = true;
+          if ($(element.options[element.selectedIndex]).attr('selected') === undefined) titleOption.selected = true;
         }
       }
 


### PR DESCRIPTION
Currently the default title option doesn't work in IE8.

This plugin checks if there is a (pre)selected option available, and only shows the title as the first default option when that check fails.

This check works fine for most browsers, but in IE8 that check is always passed.

IE8 always returns <code>selected</code> for the selected option, even if the markup doesn't have it. Other browsers return <code>null</code> in that case.

jQuery's <code>attr()</code> method is more advanced and returns the expected results

[Source ](http://stackoverflow.com/questions/20993631/detect-if-dom-element-has-really-an-attribute-defined-in-ie8)
