### PR TITLE
Fix for multiselect options incorrectly appearing as disabled in Firefox

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -520,7 +520,7 @@
             tokens = $this.data('tokens') ? $this.data('tokens') : null,
             subtext = typeof $this.data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.data('subtext') + '</small>' : '',
             icon = typeof $this.data('icon') !== 'undefined' ? '<span class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></span> ' : '',
-            isDisabled = this.disabled || this.parentElement.tagName === 'OPTGROUP' && this.parentElement.disabled;
+            isDisabled = this.disabled || (this.parentElement.tagName === 'OPTGROUP' && this.parentElement.disabled);
 
         if (icon !== '' && isDisabled) {
           icon = '<span>' + icon + '</span>';


### PR DESCRIPTION
I had the experience where some multiselect options were appearing as disabled in firefox, even though the original option elements where not disabled. This fixes it.

It appears that Firefox's js processing does `&&` / `||` priority differently than Chrome. (I didn't check other browsers)
