### PR TITLE
Fix the wrong argument name of GH-866.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -61,7 +61,7 @@ module.exports = function (grunt) {
       main: {
         options: {
           deps: {
-            args: ['jQuery'],
+            'default': ['jQuery'],
             amd: ['jquery'],
             cjs: ['jquery'],
             global: ['jQuery']
@@ -72,7 +72,7 @@ module.exports = function (grunt) {
       i18n: {
         options: {
           deps: {
-            args: ['jQuery'],
+            'default': ['jQuery'],
             amd: ['jquery'],
             cjs: ['jquery'],
             global: ['jQuery']


### PR DESCRIPTION
It fixes GH-866. The default arguments should be correct now.

``` diff
-}(this, function () {
+}(this, function (jQuery) {
```
