### PR TITLE
Added callback function sortSearchResults

### DIFF
--- a/dist/js/bootstrap-select.js
+++ b/dist/js/bootstrap-select.js
@@ -334,7 +334,7 @@
     mobile: false,
     selectOnTab: false,
     dropdownAlignRight: false,
-    sortSearchResults: null
+    sortSearchResults: null 
   };
 
   Selectpicker.prototype = {

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -310,7 +310,8 @@
     maxOptions: false,
     mobile: false,
     selectOnTab: false,
-    dropdownAlignRight: false
+    dropdownAlignRight: false,
+    sortSearchResults: null
   };
 
   Selectpicker.prototype = {
@@ -1186,6 +1187,24 @@
         that.render(false);
       });
     },
+    
+    resortItemsByOriginalIndex: function(liItems) {
+          
+          var that = this;
+          liItems.sort(function(a,b){
+          	var an = parseInt(a.getAttribute('data-original-index'),10),
+          		bn =   parseInt(b.getAttribute('data-original-index'),10);
+          
+          	if(an > bn) {
+          		return 1;
+          	}
+          	if(an < bn) {
+          		return -1;
+          	}
+          	return 0;
+          });
+          liItems.detach().appendTo(that.$menuInner);
+    },
 
     liveSearchListener: function () {
       var that = this,
@@ -1210,7 +1229,13 @@
 
       this.$searchbox.on('input propertychange', function () {
         if (that.$searchbox.val()) {
-          var $searchBase = that.$lis.not('.is-hidden').removeClass('hidden').children('a');
+          var $initialLiItems = that.$lis.not('.is-hidden').removeClass('hidden');
+          if (typeof that.options.sortSearchResults == 'function')
+          {
+            that.resortItemsByOriginalIndex($initialLiItems);
+          }
+                    
+          var $searchBase = $initialLiItems.children('a');
           if (that.options.liveSearchNormalize) {
             $searchBase = $searchBase.not(':a' + that._searchStyle() + '("' + normalizeToBase(that.$searchbox.val()) + '")');
           } else {
@@ -1241,6 +1266,16 @@
               $this.addClass('hidden');
             }
           });
+          
+          var sortedResults = [];
+          var $filteredVisibleItems = that.$lis.not('.hidden, .no-results');
+          if (typeof that.options.sortSearchResults == 'function')
+          {         
+               var searchVal = that.$searchbox.val(); 
+               sortedResults = that.options.sortSearchResults.apply(that, [searchVal, $filteredVisibleItems]);
+               jQuery(sortedResults).detach().appendTo(that.$menuInner); 
+          }
+          
 
           if (!that.$lis.not('.hidden, .no-results').length) {
             if (!!$no_results.parent().length) {
@@ -1252,14 +1287,29 @@
             $no_results.remove();
           }
         } else {
-          that.$lis.not('.is-hidden').removeClass('hidden');
+          var $initialLiItems = that.$lis.not('.is-hidden').removeClass('hidden');
+          if (typeof that.options.sortSearchResults == 'function')
+          {
+            that.resortItemsByOriginalIndex($initialLiItems);
+          }
           if (!!$no_results.parent().length) {
             $no_results.remove();
           }
         }
 
         that.$lis.filter('.active').removeClass('active');
-        if (that.$searchbox.val()) that.$lis.not('.hidden, .divider, .dropdown-header').eq(0).addClass('active').children('a').focus();
+        if (that.$searchbox.val()) {
+			var highlightedItem = null;
+        	if (sortedResults && sortedResults.length > 0)
+        	{
+           		highlightedItem = sortedResults[0];
+        	}
+        	else
+        	{
+          		highlightedItem = that.$lis.not('.hidden, .divider, .dropdown-header').eq(0);
+        	}
+        	jQuery(highlightedItem).addClass('active').children('a').focus();
+		}
         $(this).focus();
       });
     },

--- a/test.html
+++ b/test.html
@@ -67,6 +67,31 @@
       </div>
     </div>
   </form>
+  
+  
+  
+  <hr>
+
+  <form class="form-horizontal" role="form">
+    <div class="form-group">
+      <label for="basic3" class="col-lg-2 control-label">"Basic" (with liveSearch and custom search results sorting)</label>
+
+      <div class="col-lg-10">
+        <select id="basic3" class="show-tick form-control" data-live-search="true">
+          <option>AABB</option>
+          <option>AA</option>
+          <option>A</option>
+          <option>BBBB</option>
+          <option>BB</option>
+          <option>B</option>
+          <option>CCAA</option>
+          <option>CCCC</option>
+          <option>CC</option>
+          <option>C</option>
+        </select>
+      </div>
+    </div>
+  </form>
 
   <hr>
   <form class="form-horizontal" role="form">
@@ -309,6 +334,44 @@
     $('#basic2').selectpicker({
       liveSearch: true,
       maxOptions: 1
+    });
+    
+    function sortItemsByText(a, b)
+    {
+      var aName = jQuery("a .text", a).text().toLowerCase();
+    	var bName = jQuery("a .text", b).text().toLowerCase();    
+      return ((aName < bName) ? -1 : ((aName > bName) ? 1 : 0));
+    }
+    
+    $('#basic3').selectpicker({
+      liveSearch: true,
+      sortSearchResults: function(searchQuery, filteredLiItems) {
+                                /* for example we want to sort the results list by
+                                   the option text and give priotity to the items starting with the matching string
+                                    */
+                                var i=0;
+                            		var matchesStartWith = [];
+                            		var matchesContains = [];
+                               
+                            		var searchVal = searchQuery;
+                            		for(i=0;i<filteredLiItems.length;i++)
+                            		{
+                            			var currRes = filteredLiItems[i];
+                                  var curText = jQuery("a .text", currRes).text().toLowerCase();
+                            			if(curText.indexOf(searchVal) == 0)
+                            			{
+                            				matchesStartWith.push(currRes);
+                            			}
+                            			else
+                            			{
+                            				matchesContains.push(currRes);
+                            			}
+                            		}
+                                matchesStartWith.sort(sortItemsByText);
+                                matchesContains.sort(sortItemsByText);
+                                var mergedResults = matchesStartWith.concat(matchesContains);
+                                return mergedResults;
+                         }
     });
   });
 </script>


### PR DESCRIPTION
Hi,

I've implemented a new callback option named "sortSearchResults" which will let the users define a custom sorting when searching for options via live-search. 
When implemented the function passes 2 arguments:
- The current search query string
- The list of the filtered option items (i.e. <li> elements) 
  and expects to return a again an array of option items which will eventually be sorted according to whatever custom user-defined logic.

Currently when searching through live-search bootstrap-select is just "hiding" the non-matching items in the DOM therefore the sorting of the search results is exactly the same order of the items in the DOM. This might not necessarily be  the expected order of the search results.
In my case I wanted to sort the search results alphabetically and give priority to those matching options  "starting with" the current query string. 
I could not find any option to define custom sorting of the search results therefore I'm pulling a request here. See the example in test.html 

P.S. I have no idea why the lines from [8-23] are marked as changed as I haven't really edited that part 
