### PR TITLE
Add NuGet badge, links to packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,9 @@ bootstrap-select
 
 [![Latest release](https://img.shields.io/github/release/silviomoreto/bootstrap-select.svg?style=flat)](https://github.com/silviomoreto/bootstrap-select/releases/latest)
 [![Bower](https://img.shields.io/bower/v/bootstrap-select.svg)]()
-[![npm](https://img.shields.io/npm/v/bootstrap-select.svg)]()
+[![npm](https://img.shields.io/npm/v/bootstrap-select.svg)](https://www.npmjs.com/package/bootstrap-select)
+[![NuGet](https://img.shields.io/nuget/v/bootstrap-select.svg)](https://www.nuget.org/packages/bootstrap-select/)
+
 [![License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat)](LICENSE)
 [![Dependency Status](https://david-dm.org/silviomoreto/bootstrap-select.svg)](https://david-dm.org/silviomoreto/bootstrap-select)
 [![devDependency Status](https://david-dm.org/silviomoreto/bootstrap-select/dev-status.svg)](https://david-dm.org/silviomoreto/bootstrap-select#info=devDependencies)


### PR DESCRIPTION
bootstrap-select is distributed on NuGet too, so I thought I'd add a NuGet badge.

In addition, I have added a newline after the badge to make things fit a bit better, and included links to the npm and NuGet packages.

As for the relative importance of the NuGet badge: according to https://www.npmjs.com/package/bootstrap-select the project has 889 downloads in the past month, https://www.nuget.org/stats/packages/bootstrap-select?groupby=Operation has 1,880 downloads in total over six weeks but broken out by operation. The core "install" operation is 323 downloads over six weeks.

No hurt feelings if you don't want the badge, approve or decline at will.
