### PR TITLE
Add bidirectional CSS support

### DIFF
--- a/less/bootstrap-select.less
+++ b/less/bootstrap-select.less
@@ -12,7 +12,15 @@
   // The selectpicker button
   > .dropdown-toggle {
     width: 100%;
-    padding-right: 25px;
+
+    // left-to-right
+    html:not([dir=rtl]) & {
+      padding-right: 25px;
+    }
+    // right-to-left
+    html[dir=rtl] & {
+      padding-left: 25px;
+    }
   }
 
   // Error display
@@ -56,7 +64,15 @@
   &[class*="col-"] {
     float: none;
     display: inline-block;
-    margin-left: 0;
+
+    // left-to-right
+    html:not([dir=rtl]) & {
+      margin-left: 0;
+    }
+    // right-to-left
+    html[dir=rtl] & {
+      margin-left: 0;
+    }
   }
 
   // Forces the pull to the right, if necessary
@@ -64,7 +80,14 @@
   &[class*="col-"],
   .row &[class*="col-"] {
     &.dropdown-menu-right {
-      float: right;
+      // left-to-right
+      html:not([dir=rtl]) & {
+        float: right;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        float: left;
+      }
     }
   }
 
@@ -108,15 +131,31 @@
       display: inline-block;
       overflow: hidden;
       width: 100%;
-      text-align: left;
+
+      // left-to-right
+      html:not([dir=rtl]) & {
+        text-align: left;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        text-align: right;
+      }
     }
 
     .caret {
       position: absolute;
       top: 50%;
-      right: 12px;
       margin-top: -2px;
       vertical-align: middle;
+
+      // left-to-right
+      html:not([dir=rtl]) & {
+        right: 12px;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        left: 12px;
+      }
     }
   }
 
@@ -159,7 +198,15 @@
 
         &.opt {
           position: relative;
-          padding-left: 2.25em;
+
+          // left-to-right
+          html:not([dir=rtl]) & {
+            padding-left: 2.25em;
+          }
+          // right-to-left
+          html[dir=rtl] & {
+            padding-right: 2.25em;
+          }
         }
 
         span.check-mark {
@@ -172,7 +219,14 @@
       }
 
       small {
-        padding-left: 0.5em;
+        // left-to-right
+        html:not([dir=rtl]) & {
+          padding-left: 0.5em;
+        }
+        // right-to-left
+        html[dir=rtl] & {
+          padding-right: 0.5em;
+        }
       }
     }
 
@@ -215,12 +269,27 @@
     &.selected a span.check-mark {
       position: absolute;
       display: inline-block;
-      right: 15px;
       margin-top: 5px;
+
+      // left-to-right
+      html:not([dir=rtl]) & {
+        right: 15px;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        left: 15px;
+      }
     }
 
     a span.text {
-      margin-right: 34px;
+      // left-to-right
+      html:not([dir=rtl]) & {
+        margin-right: 34px;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        margin-left: 34px;
+      }
     }
   }
 }
@@ -238,8 +307,16 @@
       border-bottom: 7px solid @color-grey-arrow;
       position: absolute;
       bottom: -4px;
-      left: 9px;
       display: none;
+
+      // left-to-right
+      html:not([dir=rtl]) & {
+        left: 9px;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        right: 9px;
+      }
     }
 
     &:after {
@@ -249,8 +326,16 @@
       border-bottom: 6px solid white;
       position: absolute;
       bottom: -4px;
-      left: 10px;
       display: none;
+
+      // left-to-right
+      html:not([dir=rtl]) & {
+        left: 10px;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        right: 10px;
+      }
     }
   }
 
@@ -272,13 +357,29 @@
 
   &.pull-right .dropdown-toggle {
     &:before {
-      right: 12px;
-      left: auto;
+      // left-to-right
+      html:not([dir=rtl]) & {
+        right: 12px;
+        left: auto;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        left: 12px;
+        right: auto;
+      }
     }
 
     &:after {
-      right: 13px;
-      left: auto;
+      // left-to-right
+      html:not([dir=rtl]) & {
+        right: 13px;
+        left: auto;
+      }
+      // right-to-left
+      html[dir=rtl] & {
+        left: 13px;
+        right: auto;
+      }
     }
   }
 
@@ -306,9 +407,17 @@
 }
 
 .bs-donebutton {
-  float: left;
   width: 100%;
   box-sizing: border-box;
+
+  // left-to-right
+  html:not([dir=rtl]) & {
+    float: left;
+  }
+  // right-to-left
+  html[dir=rtl] & {
+    float: right;
+  }
 
   & .btn-group button {
     width: 100%;
@@ -335,9 +444,17 @@ select.selectpicker {
 select.mobile-device {
   position: absolute !important;
   top: 0;
-  left: 0;
   display: block !important;
   width: 100%;
   height: 100% !important;
   opacity: 0;
+
+  // left-to-right
+  html:not([dir=rtl]) & {
+    left: 0;
+  }
+  // right-to-left
+  html[dir=rtl] & {
+    right: 0;
+  }
 }


### PR DESCRIPTION
Allow both left-to-right and right-to-left layouts using a single CSS file.

Supersedes #572.
