### PR TITLE
Update license attribute and improve JS code

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -14,7 +14,7 @@ module.exports = function (grunt) {
     ' * Bootstrap-select v<%= pkg.version %> (<%= pkg.homepage %>)\n' +
     ' *\n' +
     ' * Copyright 2013-<%= grunt.template.today(\'yyyy\') %> bootstrap-select\n' +
-    ' * Licensed under <%= pkg.license.type %> (<%= pkg.license.url %>)\n' +
+    ' * Licensed under <%= pkg.license %> (https://github.com/silviomoreto/bootstrap-select/blob/master/LICENSE)\n' +
     ' */\n',
 
     // Task configuration.
@@ -177,7 +177,6 @@ module.exports = function (grunt) {
       versionNumber: {
         path: [
           'js/<%= pkg.name %>.js',
-          'bower.json',
           'composer.json',
           'package.json'
         ],

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -118,11 +118,11 @@
       // initialize object and result
       r=[];
       // iterate over object keys
-      for (k in o) 
+      for (k in o)
           // fill result array with non-prototypical keys
         r.hasOwnProperty.call(o, k) && r.push(k);
       // return result
-      return r
+      return r;
     };
   }
 
@@ -946,7 +946,7 @@
 
     setSelected: function (index, selected, $lis) {
       if (!$lis) {
-        var $lis = this.findLis().eq(this.liObj[index]);
+        $lis = this.findLis().eq(this.liObj[index]);
       }
 
       $lis.toggleClass('selected', selected);
@@ -954,7 +954,7 @@
 
     setDisabled: function (index, disabled, $lis) {
       if (!$lis) {
-        var $lis = this.findLis().eq(this.liObj[index]);
+        $lis = this.findLis().eq(this.liObj[index]);
       }
 
       if (disabled) {
@@ -1265,18 +1265,12 @@
     },
 
     _searchStyle: function () {
-      var style = 'icontains';
-      switch (this.options.liveSearchStyle) {
-        case 'begins':
-        case 'startsWith':
-          style = 'ibegins';
-          break;
-        case 'contains':
-        default:
-          break; //no need to change the default
-      }
+      var styles = {
+        begins: 'ibegins',
+        startsWith: 'ibegins'
+      };
 
-      return style;
+      return styles[this.options.liveSearchStyle] || 'icontains';
     },
 
     val: function (value) {

--- a/package.json
+++ b/package.json
@@ -35,10 +35,7 @@
     "type": "git",
     "url": "git://github.com/silviomoreto/bootstrap-select.git"
   },
-  "license": {
-    "type": "MIT",
-    "url": "https://github.com/silviomoreto/bootstrap-select/blob/master/LICENSE"
-  },
+  "license": "MIT",
   "dependencies": {
     "jquery": ">=1.8"
   },


### PR DESCRIPTION
Specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/

`version` not exists in `bower.json` after merge #1062.
