### PR TITLE
Fix escaping character in select tooltips.

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -230,6 +230,24 @@
     }) : string;
   }
 
+  function htmlUnescape(html) {
+    var unescapeMap = {
+      '&amp;' : '&',
+      '&lt;' : '<',
+      '&gt;' : '>',
+      '&quot;' : '"',
+      '&#x27;' : "'",
+      '&#x60;' :'`'
+    };
+      var source = '(?:' + Object.keys(unescapeMap).join('|') + ')',
+          testRegexp = new RegExp(source),
+          replaceRegexp = new RegExp(source, 'g'),
+          string = html == null ? '' : '' + html;
+      return testRegexp.test(string) ? string.replace(replaceRegexp, function (match) {
+        return unescapeMap[match];
+      }) : string;
+    }
+
   var Selectpicker = function (element, options, e) {
     if (e) {
       e.stopPropagation();
@@ -687,7 +705,7 @@
       }
 
       //strip all html-tags and trim the result
-      this.$button.attr('title', $.trim(title.replace(/<[^>]*>?/g, '')));
+      this.$button.attr('title', htmlUnescape(title));
       this.$button.children('.filter-option').html(title);
 
       this.$element.trigger('rendered.bs.select');


### PR DESCRIPTION
Hello I found out that displaying tooltip with html escaped characters didint work properly. Title was escaped even if it dont have to be. So i made made unescape function and calling it for title.
Before:
![titlebugbroken](https://cloud.githubusercontent.com/assets/9535558/11532997/b89d08e2-9907-11e5-84ef-26dedc3a0671.png)
After:
![titlebugfixed](https://cloud.githubusercontent.com/assets/9535558/11533000/ba400cc6-9907-11e5-9751-c8a762ba96d7.png)
