### PR TITLE
Restore select to its original position when destroying

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1592,7 +1592,7 @@
     },
 
     destroy: function () {
-        this.$newElement.remove();
+        this.$newElement.before(this.$element).remove();
 
         if (this.$bsContainer) {
             this.$bsContainer.remove();


### PR DESCRIPTION
In my opinion, when destroying the bootstrap-select element, it should restore the select to its original position. In 1.7.7 (where I first noticed the issue) it was only an issue with the mobile version, but since `this.$element` is now always appended to `this.$newElement`, it's an issue in general.
