### PR TITLE
wai-aria and accesiliby fixes

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -451,7 +451,7 @@
           header +
           searchbox +
           actionsbox +
-          '<ul class="dropdown-menu inner" role="menu">' +
+          '<ul class="dropdown-menu inner" role="listbox">' +
           '</ul>' +
           donebutton +
           '</div>' +
@@ -500,7 +500,7 @@
             ((typeof classes !== 'undefined' & '' !== classes) ? ' class="' + classes + '"' : '') +
             ((typeof index !== 'undefined' & null !== index) ? ' data-original-index="' + index + '"' : '') +
             ((typeof optgroup !== 'undefined' & null !== optgroup) ? 'data-optgroup="' + optgroup + '"' : '') +
-            '>' + content + '</li>';
+            ' role="option">' + content + '</li>';
       };
 
       /**
@@ -1077,6 +1077,12 @@
         }
       });
 
+      this.$menuInner.on('keypress', 'li a', function (e) {
+    	  if (e.which == 13) {
+    		$(this).click();
+    	    return false;  
+    	  }
+      });
       this.$menuInner.on('click', 'li a', function (e) {
         var $this = $(this),
             clickedIndex = $this.parent().data('originalIndex'),
@@ -1426,7 +1432,7 @@
 
       if (that.options.container) $parent = that.$menu;
 
-      $items = $('[role=menu] li', $parent);
+      $items = $('[role=listbox] li', $parent);
 
       isActive = that.$newElement.hasClass('open');
 
@@ -1449,7 +1455,7 @@
           that.$button.focus();
         }
         // $items contains li elements when liveSearch is enabled
-        $items = $('[role=menu] li' + selector, $parent);
+        $items = $('[role=listbox] li' + selector, $parent);
         if (!$this.val() && !/(38|40)/.test(e.keyCode.toString(10))) {
           if ($items.filter('.active').length === 0) {
             $items = that.$menuInner.find('li');
@@ -1677,8 +1683,8 @@
 
   $(document)
       .data('keycount', 0)
-      .on('keydown.bs.select', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role="menu"], .bs-searchbox input', Selectpicker.prototype.keydown)
-      .on('focusin.modal', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role="menu"], .bs-searchbox input', function (e) {
+      .on('keydown.bs.select', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role="listbox"], .bs-searchbox input', Selectpicker.prototype.keydown)
+      .on('focusin.modal', '.bootstrap-select [data-toggle=dropdown], .bootstrap-select [role="listbox"], .bs-searchbox input', function (e) {
         e.stopPropagation();
       });
 


### PR DESCRIPTION
The select should be roled as "listbox" and the options as "option", this fix make the select respect the WAI-ARIA 1.0 standard. Added an hook for "enter key" pressed, so the component can be used with keyboard too.
