### PR TITLE
setStyle: remember previous style

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -724,6 +724,7 @@
       } else {
         this.$button.removeClass(this.options.style);
         this.$button.addClass(buttonClass);
+        this.options.style = buttonClass
       }
     },
 


### PR DESCRIPTION
Repeatedly calling `setStyle(newStyle)` does not work, as `removeClass`only removes the original `this.options.style` value.

`this.options.style` should be set to `buttonClass`.
