### PR TITLE
Hide the optgroup header/divider when appropriate

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -562,6 +562,13 @@
           icon = '<span>' + icon + '</span>';
         }
 
+        // If the optgroup is disabled don't generate anything
+        // (not even the optgroup header and divider)
+        if (that.options.hideDisabled && isOptgroup && this.parentNode.disabled) {
+          liIndex--;
+          return;
+        }
+        
         if (that.options.hideDisabled && isDisabled && !isOptgroup) {
           liIndex--;
           return;


### PR DESCRIPTION
When an optgroup is disabled (and you are using the data-hide-disabled option) all child options are hidden, but the optgroup header and divider are still displayed.

This hides the optgroup header and divider for that case. #1338 
