### PR TITLE
Allow jQuery 1.8.0 - 1.11.3

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,7 +16,7 @@
     "replacement"
   ],
   "dependencies": {
-    "jquery": ">=1.8"
+    "jquery": "1.8.0 - 1.11.3"
   },
   "license": "MIT",
   "ignore": [

--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
   ],
   "license": "MIT",
   "suggest": {
-    "components/jquery": ">=1.8",
+    "components/jquery": "1.8.0 - 1.11.3",
     "twbs/bootstrap": "~3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "jquery": ">=1.8"
+    "jquery": "1.8.0 - 1.11.3"
   },
   "devDependencies": {
     "grunt": "~0.4.5",


### PR DESCRIPTION
This allows for later versions to be used when installing automatically via npm. Later versions of jQuery do not install a bunch on unused dependencies, and do not need to use node-gyp, which makes for much faster installs.

Hat tip to the maintainers of backbone.marionette, where I picked up this trick (see https://github.com/marionettejs/backbone.marionette/commit/1d6fa16512eafc3c3fbcbda5a3f1b650bc93680a).
#### Background
1. In a disposable folder, `npm install jquery@1.8.3`
2. Observe that `node-gyp` is called for `contextify`, and that a bunch of dependencies are installed.
3. In a new disposable folder, `npm install jquery@1.11.3`
4. Observe that node-gyp is not called, and that only one dependency is installed
