### PR TITLE
Allow HTML in title

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -533,7 +533,7 @@
           // Use native JS to prepend option (faster)
           var element = this.$element[0];
           titleOption.className = 'bs-title-option';
-          titleOption.appendChild(document.createTextNode(this.options.title));
+          titleOption.innerHTML=this.options.title;
           titleOption.value = '';
           element.insertBefore(titleOption, element.firstChild);
           // Check if selected attribute is already set on an option. If not, select the titleOption option.


### PR DESCRIPTION
Default title option doesn't allow HTML rendering. All html tags are converted to text.

This fix the issue
