### PR TITLE
trigger setSize on refresh event

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1704,6 +1704,7 @@
       this.render();
       this.checkDisabled();
       this.liHeight(true);
+      this.setSize();
       this.setStyle();
       this.setWidth();
       if (this.$lis) this.$searchbox.trigger('propertychange');


### PR DESCRIPTION
setSize needs to be executed in order to reflect new size when the options have been populated programmatically (eg. via ajax). This issue happens when listening for **show.bs.select** and populate the options within that function.

Test case:

``` javasript
$('.selectpicker').on('show.bs.select', function (e) {
        // do ajax request and when done,
        $('.selectpicker').selectpicker('refresh'); // needs to trigger setSize
});
```

Currently, when the options has been populated via ajax, the dropdown has been already opened and it shows all items (because rendered all **li's**), and once closed and opened again it shows the correct size. This is because setSize is set only when 

``` javascript
this.$button.on('click', function () {
        that.setSize();
});
```

which the event happens before **show.bs.select**.
