### PR TITLE
take searchHeight into account when calculating inner menu's max-height

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1012,7 +1012,7 @@
           'min-height': ''
         });
         $menuInner.css({
-          'max-height': menuHeight - menuPadding.vert + 'px',
+          'max-height': menuHeight - searchHeight - menuPadding.vert + 'px',
           'overflow-y': 'auto',
           'min-height': ''
         });


### PR DESCRIPTION
In situations when size is set and liveSearch is also set to true, $menuInner max-height didn't take into account it's height and the max-height was wrong..
