### PR TITLE
Added support for window padding

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -269,6 +269,19 @@
       this.options.title = this.$element.attr('title');
     }
 
+    // Format window padding
+    var winPad = this.options.windowPadding;
+    switch (typeof winPad) {
+      case "number":
+        this.options.windowPadding = [winPad, winPad, winPad, winPad];
+        break;
+      case "string":
+        this.options.windowPadding = winPad.split(" ").map(function(v){
+          return parseInt(v, 10);
+        });
+        break;
+    }
+
     //Expose public methods
     this.val = Selectpicker.prototype.val;
     this.render = Selectpicker.prototype.render;
@@ -331,7 +344,8 @@
     maxOptions: false,
     mobile: false,
     selectOnTab: false,
-    dropdownAlignRight: false
+    dropdownAlignRight: false,
+    windowPadding: 0
   };
 
   Selectpicker.prototype = {
@@ -921,10 +935,13 @@
               containerPos = { top: 0, left: 0 };
             }
 
+            var winPad = that.options.windowPadding;
             selectOffsetTop = pos.top - containerPos.top - $window.scrollTop();
-            selectOffsetBot = $window.height() - selectOffsetTop - selectHeight - containerPos.top;
+            selectOffsetBot = $window.height() - selectOffsetTop - selectHeight - containerPos.top - winPad[2];
             selectOffsetLeft = pos.left - containerPos.left - $window.scrollLeft();
-            selectOffsetRight = $window.width() - selectOffsetLeft - selectWidth - containerPos.left;
+            selectOffsetRight = $window.width() - selectOffsetLeft - selectWidth - containerPos.left - winPad[1];
+            selectOffsetTop -= winPad[0];
+            selectOffsetLeft -= winPad[3];
           };
 
       getPos();

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -271,15 +271,8 @@
 
     // Format window padding
     var winPad = this.options.windowPadding;
-    switch (typeof winPad) {
-      case "number":
-        this.options.windowPadding = [winPad, winPad, winPad, winPad];
-        break;
-      case "string":
-        this.options.windowPadding = winPad.split(" ").map(function(v){
-          return parseInt(v, 10);
-        });
-        break;
+    if (typeof winPad === 'number') {
+      this.options.windowPadding = [winPad, winPad, winPad, winPad];
     }
 
     //Expose public methods


### PR DESCRIPTION
As described in #1502.
Added an option called `windowPadding`, which supports the formats `x`, ~~`"x y z k"`~~ and `[x, y, z, k]`, where `x`, `y`, `z` and `k` are integers. The string and array formats use the normal CSS order (top-right-bottom-left), while the number format applies to all sides.

[Fixed JSFiddle.](https://jsfiddle.net/rvaq2a11/)

Image comparisons:

<p align="center">
  <img align="top" src="https://cloud.githubusercontent.com/assets/4542461/18387599/bda6f9e6-769d-11e6-8b07-2ac30525df04.png" />
  <img align="top" src="https://cloud.githubusercontent.com/assets/4542461/18389126/ad76894a-76a4-11e6-956e-dd565d3d03a4.png" />
</p>
