### PR TITLE
Fix bs-placeholder usage for jQuery>=3.0

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1168,7 +1168,7 @@
 
     togglePlaceholder: function () {
       var value = this.$element.val();
-      this.$button.toggleClass('bs-placeholder', value === null || value === '');
+      this.$button.toggleClass('bs-placeholder', value === null || value === '' || (value.constructor === Array && value.length === 0));
     },
 
     tabIndex: function () {


### PR DESCRIPTION
jQuery 3.0 introduced a breaking change in the empty value of multi select boxes.

For details, see https://jquery.com/upgrade-guide/3.0/#breaking-change-select-multiple-with-nothing-selected-returns-an-empty-array
