### PR TITLE
Update bootstrap-select.js

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1212,7 +1212,7 @@
 
           // scroll to selected option
           var offset = that.$lis.eq(selectedIndex)[0].offsetTop - that.$menuInner[0].offsetTop;
-          offset = offset - that.$menuInner[0].offsetHeight/2 + that.sizeInfo.liHeight/2;
+          offset = offset - that.$menuInner[0].offsetHeight/2 + that.liHeight/2;
           that.$menuInner[0].scrollTop = offset;
         }
       });


### PR DESCRIPTION
the object "that" was not assigned sizeInfo but each sub element of sizeInfo directly.  Thus the correct code would be that.liHeight versus that.sizeInfo.liHeight.
