### PR TITLE
Create a ul for each optgroup

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -501,7 +501,7 @@
           header +
           searchbox +
           actionsbox +
-          '<ul class="dropdown-menu inner" role="listbox" aria-expanded="false">' +
+          '<ul class="dropdown-menu inner open" role="listbox" aria-expanded="false">' +
           '</ul>' +
           donebutton +
           '</div>' +
@@ -657,14 +657,17 @@
             }
             liIndex++;
             _li.push(generateLI(label, null, 'dropdown-header' + optGroupClass, optID));
+            _li.push('<ul class="dropdown-menu inner optgroup" data-optgroup="' + optID + '">');
           }
 
           if (that.options.hideDisabled && isDisabled) {
             liIndex--;
+            if (!this.nextElementSibling) _li.push('</ul>'); // Is it the last option of the optgroup?
             return;
           }
 
           _li.push(generateLI(generateA(text, 'opt ' + optionClass + optGroupClass, inline, tokens), index, '', optID));
+          if (!this.nextElementSibling) _li.push('</ul>'); // Is it the last option of the optgroup?
         } else if ($this.data('divider') === true) {
           _li.push(generateLI('', index, 'divider'));
         } else if ($this.data('hidden') === true) {


### PR DESCRIPTION
This change creates a `ul` wrapper around all `li`s associated to an optgroup, allowing the optgroups to be targeted/styled using the `.optgroup` class.
Fixes #1401, should also make it easier to do things such as select/deselect all (#737) or collapsing (#1159).
I've noticed that doing this also improves rendering performance for large lists.

(I've recreated this PR as I accidentally destroyed the previous one)
