### PR TITLE
Move "dropdown-toggle" into styleBase-option

### DIFF
--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -241,9 +241,18 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
   <tr>
     <td>styleBase</td>
     <td>string</td>
-    <td><code>btn dropdown-toggle</code></td>
+    <td><code>btn</code></td>
     <td>
       <p>Base style for all buttons.</p>
+    </td>
+  </tr>
+  <tr>
+  <tr>
+    <td>styleDropdown</td>
+    <td>string</td>
+    <td><code>dropdown-toggle</code></td>
+    <td>
+      <p>Dropdown style for all buttons.</p>
     </td>
   </tr>
   <tr>

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -241,7 +241,7 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
   <tr>
     <td>styleBase</td>
     <td>string</td>
-    <td><code>btn</code></td>
+    <td><code>btn dropdown-toggle</code></td>
     <td>
       <p>Base style for all buttons.</p>
     </td>

--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -239,6 +239,15 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </td>
   </tr>
   <tr>
+    <td>styleBase</td>
+    <td>string</td>
+    <td><code>btn</code></td>
+    <td>
+      <p>Base style for all buttons.</p>
+    </td>
+  </tr>
+  <tr>
+  <tr>
     <td>style</td>
     <td>string | null</td>
     <td><code>null</code></td>

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -329,7 +329,7 @@
     doneButton: false,
     doneButtonText: 'Close',
     multipleSeparator: ', ',
-    styleBase: 'btn',
+    styleBase: 'btn dropdown-toggle',
     style: 'btn-default',
     size: 'auto',
     title: null,
@@ -491,7 +491,7 @@
           : '';
       var drop =
           '<div class="btn-group bootstrap-select' + showTick + inputGroup + '">' +
-          '<button type="button" class="' + this.options.styleBase + ' dropdown-toggle" data-toggle="dropdown"' + autofocus + ' role="button">' +
+          '<button type="button" class="' + this.options.styleBase + '" data-toggle="dropdown"' + autofocus + ' role="button">' +
           '<span class="filter-option pull-left"></span>&nbsp;' +
           '<span class="bs-caret">' +
           this.options.template.caret +

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -329,7 +329,8 @@
     doneButton: false,
     doneButtonText: 'Close',
     multipleSeparator: ', ',
-    styleBase: 'btn dropdown-toggle',
+    styleBase: 'btn',
+    styleDropdown: 'dropdown-toggle',
     style: 'btn-default',
     size: 'auto',
     title: null,
@@ -491,7 +492,7 @@
           : '';
       var drop =
           '<div class="btn-group bootstrap-select' + showTick + inputGroup + '">' +
-          '<button type="button" class="' + this.options.styleBase + '" data-toggle="dropdown"' + autofocus + ' role="button">' +
+          '<button type="button" class="' + this.options.styleBase + ' ' + this.options.styleDropdown + '" data-toggle="dropdown"' + autofocus + ' role="button">' +
           '<span class="filter-option pull-left"></span>&nbsp;' +
           '<span class="bs-caret">' +
           this.options.template.caret +


### PR DESCRIPTION
I was trying to overwrite all styles for the select-button. Unfortunatly "dropdown-toggle" was added to the button anyway, so I looked and found the (undocumented) styleBase option.
So I added a documentation for it and moved the dropdown-toggle class into it. 

This MIGHT break for people that already use the styleBase-option and depend on the dropdown-toggle-styling so I am more then eager to hear your opinion on this.
