### PR TITLE
Use default with SCSS variables

### DIFF
--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -1,9 +1,9 @@
-$color-red-error: rgb(185, 74, 72);
-$color-grey-arrow: rgba(204, 204, 204, 0.2);
+$color-red-error: rgb(185, 74, 72) !default;
+$color-grey-arrow: rgba(204, 204, 204, 0.2) !default;
 
-$width-default: 220px; // 3 960px-grid columns
+$width-default: 220px !default; // 3 960px-grid columns
 
-$zindex-select-dropdown: 1060; // must be higher than a modal background (1050)
+$zindex-select-dropdown: 1060 !default; // must be higher than a modal background (1050)
 
 //** Placeholder text color
-$input-color-placeholder: #999;
+$input-color-placeholder: #999 !default;


### PR DESCRIPTION
That way applications can easily customize the style without having to write a bunch of CSS to overcome the delivered stuff.