### PR TITLE
Add a `liveSearchNumber` option

### DIFF
--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -126,6 +126,14 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </td>
   </tr>
   <tr>
+    <td>liveSearchNumber</td>
+    <td>boolean</td>
+    <td><code>false</code></td>
+    <td>
+      <p>When set to <code>true</code>, the input type of the search field will be changed so that a numeric keypad is displayed on mobile devices instead of a full keyboard.</p>
+    </td>
+  </tr>
+  <tr>
     <td>maxOptions</td>
     <td>integer | false</td>
     <td><code>false</code></td>

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -235,7 +235,7 @@
     "'": '&#x27;',
     '`': '&#x60;'
   };
-  
+
   var unescapeMap = {
     '&amp;': '&',
     '&lt;': '<',
@@ -338,6 +338,7 @@
     dropupAuto: true,
     header: false,
     liveSearch: false,
+    liveSearchNumber: false,
     liveSearchPlaceholder: null,
     liveSearchNormalize: false,
     liveSearchStyle: 'contains',
@@ -459,7 +460,7 @@
       var header = this.options.header ? '<div class="popover-title"><button type="button" class="close" aria-hidden="true">&times;</button>' + this.options.header + '</div>' : '';
       var searchbox = this.options.liveSearch ?
       '<div class="bs-searchbox">' +
-      '<input type="text" class="form-control" autocomplete="off"' +
+      '<input type="' + (this.options.liveSearchNumber ? 'tel' : 'text') + '" class="form-control" autocomplete="off"' +
       (null === this.options.liveSearchPlaceholder ? '' : ' placeholder="' + htmlEscape(this.options.liveSearchPlaceholder) + '"') + ' role="textbox" aria-label="Search">' +
       '</div>'
           : '';
@@ -1190,7 +1191,7 @@
     },
 
     tabIndex: function () {
-      if (this.$element.data('tabindex') !== this.$element.attr('tabindex') && 
+      if (this.$element.data('tabindex') !== this.$element.attr('tabindex') &&
         (this.$element.attr('tabindex') !== -98 && this.$element.attr('tabindex') !== '-98')) {
         this.$element.data('tabindex', this.$element.attr('tabindex'));
         this.$button.attr('tabindex', this.$element.data('tabindex'));
@@ -1493,13 +1494,13 @@
           $lisVisible = this.$lis.not('.divider, .dropdown-header, .disabled, .hidden'),
           lisVisLen = $lisVisible.length,
           selectedOptions = [];
-          
+
       if (status) {
         if ($lisVisible.filter('.selected').length === $lisVisible.length) return;
       } else {
         if ($lisVisible.filter('.selected').length === 0) return;
       }
-          
+
       $lisVisible.toggleClass('selected', status);
 
       for (var i = 0; i < lisVisLen; i++) {


### PR DESCRIPTION
Switches the input type from `text` to `tel`. Mobile devices will display only a numeric keypad instead of a full keyboard.
Fixes #1492.

Chose against leaving `liveSearchType` fully free in order to ensure correct use.
Possible enhancement: allow `email` input type. Not sure about the added value (I think this is less common as year or numeric reference selection).