### PR TITLE
Fix positioning issue on panned/zoomed viewport on chrome with container: body

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -263,6 +263,12 @@
   var htmlEscape = createEscaper(escapeMap);
   var htmlUnescape = createEscaper(unescapeMap);
 
+  function getOffset(element) {
+    var docRect = document.documentElement.getBoundingClientRect(),
+        elemRect = element[0].getBoundingClientRect();
+    return {top: elemRect.top - docRect.top, left: elemRect.left - docRect.left};
+  }
+
   var Selectpicker = function (element, options) {
     // bootstrap-select has been initialized - revert valHooks.select.set back to its original function
     if (!valHooks.useDefault) {
@@ -928,12 +934,12 @@
           selectOffsetLeft,
           selectOffsetRight,
           getPos = function() {
-            var pos = that.$newElement.offset(),
+            var pos = getOffset(that.$newElement),
                 $container = $(that.options.container),
                 containerPos;
 
             if (that.options.container && !$container.is('body')) {
-              containerPos = $container.offset();
+              containerPos = getOffset($container);
               containerPos.top += parseInt($container.css('borderTopWidth'));
               containerPos.left += parseInt($container.css('borderLeftWidth'));
             } else {
@@ -1087,7 +1093,7 @@
           actualHeight,
           getPlacement = function ($element) {
             that.$bsContainer.addClass($element.attr('class').replace(/form-control|fit-width/gi, '')).toggleClass('dropup', $element.hasClass('dropup'));
-            pos = $element.offset();
+            pos = getOffset($element);
 
             if (!$container.is('body')) {
               containerPos = $container.offset();


### PR DESCRIPTION
jQuery `offset()` seems to returns wrong absolute position in chrome when viewport is panned/zoomed, resulting in wrongly positioned bootstrap select with `container` set. Alternative method using standardized `getBoundingClientRect` (see http://stackoverflow.com/questions/442404/retrieve-the-position-x-y-of-an-html-element) fixes the problem.

To reproduce issue, go to examples, turn on Device emulation in chrome devtools, apply some zoom to viewport and click on dropdown with container: 'body'. Dropdown is ill-positioned:

<img width="316" alt="screen shot 2017-02-12 at 19 08 45" src="https://cloud.githubusercontent.com/assets/740797/22864752/37aa4642-f157-11e6-9525-1b515f41cde1.png">
