### PR TITLE
Fix <li> tags inside <option> being treated as options

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -709,7 +709,7 @@
     },
 
     findLis: function () {
-      if (this.$lis == null) this.$lis = this.$menu.find('li');
+      if (this.$lis == null) this.$lis = this.$menu.find('ul.dropdown-menu > li');
       return this.$lis;
     },
 


### PR DESCRIPTION
The `findLis()` function used a too broad selector which included `<li>` tags inside `<option>`. For example for this `<select>`:

```
<select>
  <option><ul><li>demo</li></option>
</select>
```

`findLis()` would find two `<li>`s in generated code: one for `<option>` and one inside it.

One side effect of this bug is that check mark is shown properly only for the first option. For following options the `selected` class is assigned to incorrect `<li>`.