### PR TITLE
Improve init performance

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -385,10 +385,6 @@
 
       if (typeof id !== 'undefined') {
         this.$button.attr('data-id', id);
-        $('label[for="' + id + '"]').click(function (e) {
-          e.preventDefault();
-          that.$button.focus();
-        });
       }
 
       this.checkDisabled();
@@ -1398,6 +1394,10 @@
         that.render(false);
         that.$element.trigger('changed.bs.select', changed_arguments);
         changed_arguments = null;
+      });
+
+      this.$element.focus(function () {
+        that.$button.focus();
       });
     },
 


### PR DESCRIPTION
This PR improves initialisation performance in two ways:
1. Changes detection of first optgroup option from `$this.index() === 0` to `!this.previousElementSibling`. This makes a huge difference for large optgroups.
2. Sets necessary selected/disabled attributes during li creation, so the render doesn't have to update them during init/refresh.
3. Listens for focus on the select element instead of finding labels. This has the added advantage of also working for implicit labels.

I found this improved speed by a minimum of 2x with no optgroups, but over 10x for an optgroup with 2k options.