### PR TITLE
permit use options 'size' and 'dropdownAlignRight':'auto' together

### DIFF
--- a/dist/js/bootstrap-select.js
+++ b/dist/js/bootstrap-select.js
@@ -1045,8 +1045,16 @@
         if (that.options.container) {
           if (!$menu.data('height')) $menu.data('height', $menu.height());
           getHeight = $menu.data('height');
+          if (!$menu.data('width')) $menu.data('width', $menu.width());
+          getWidth = $menu.data('width');
         } else {
           getHeight = $menu.height();
+          getWidth = $menu.width();
+        }
+        menuWidth = selectOffsetRight - menuExtras.horiz;
+
+        if (that.options.dropdownAlignRight === 'auto') {
+          $menu.toggleClass('dropdown-menu-right', selectOffsetLeft > selectOffsetRight && (menuWidth - menuExtras.horiz) < (getWidth - selectWidth));
         }
 
         if (that.options.dropupAuto) {


### PR DESCRIPTION
Não é possível utilizar as Options `'size'` e `'dropdownAlignRight'` (como `'auto'`) ao mesmo tempo.

Se a option `'size'` estiver presente, somente é possível utilizar a option `'dropdownAlignRight'` como `true`, ou seja, SEMPRE alinhado a direita.


Código de exemplo sobre como está atualmente: (exemplo adaptado à partir do código do **`akfgln`**)
https://jsfiddle.net/b48qnf6d/4/