### PR TITLE
Actualize 'selected' attribute on Select All action.

### DIFF
--- a/dist/js/bootstrap-select.js
+++ b/dist/js/bootstrap-select.js
@@ -414,9 +414,7 @@
 
       this.$element.removeClass('bs-select-hidden');
 
-      if (this.options.dropdownAlignRight === true) {
-        this.$menu.addClass('dropdown-menu-right');
-      }
+      if (this.options.dropdownAlignRight === true) this.$menu.addClass('dropdown-menu-right');
 
       if (typeof id !== 'undefined') {
         this.$button.attr('data-id', id);
@@ -428,13 +426,10 @@
 
       this.checkDisabled();
       this.clickListener();
-      if (this.options.liveSearch) {
-        this.liveSearchListener();
-      }
+      if (this.options.liveSearch) this.liveSearchListener();
       this.render();
       this.setStyle();
-      this.setWidth();
-      
+      this.setWidth();      
       if (this.options.container) this.selectPosition();
       this.$menu.data('this', this);
       this.$newElement.data('this', this);

--- a/dist/js/bootstrap-select.js
+++ b/dist/js/bootstrap-select.js
@@ -429,7 +429,7 @@
       if (this.options.liveSearch) this.liveSearchListener();
       this.render();
       this.setStyle();
-      this.setWidth();      
+      this.setWidth();
       if (this.options.container) this.selectPosition();
       this.$menu.data('this', this);
       this.$newElement.data('this', this);

--- a/dist/js/bootstrap-select.js
+++ b/dist/js/bootstrap-select.js
@@ -414,7 +414,9 @@
 
       this.$element.removeClass('bs-select-hidden');
 
-      if (this.options.dropdownAlignRight === true) this.$menu.addClass('dropdown-menu-right');
+      if (this.options.dropdownAlignRight === true) {
+        this.$menu.addClass('dropdown-menu-right');
+      }
 
       if (typeof id !== 'undefined') {
         this.$button.attr('data-id', id);
@@ -426,10 +428,13 @@
 
       this.checkDisabled();
       this.clickListener();
-      if (this.options.liveSearch) this.liveSearchListener();
+      if (this.options.liveSearch) {
+        this.liveSearchListener();
+      }
       this.render();
       this.setStyle();
       this.setWidth();
+      
       if (this.options.container) this.selectPosition();
       this.$menu.data('this', this);
       this.$newElement.data('this', this);
@@ -1548,7 +1553,9 @@
         selectedOptions[selectedOptions.length] = $options.eq(origIndex)[0];
       }
 
-      $(selectedOptions).prop('selected', status);
+      $(selectedOptions)
+        .prop('selected', status)
+        .attr('selected', state);
 
       this.render(false);
 

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1525,8 +1525,10 @@
         selectedOptions[selectedOptions.length] = $options.eq(origIndex)[0];
       }
 
-      $(selectedOptions).prop('selected', status);
-
+      $(selectedOptions)
+      .prop('selected', status)
+      .attr('selected', state);
+      
       this.render(false);
 
       this.togglePlaceholder();


### PR DESCRIPTION
If some option not selected before calling 'selectAll' action, click on the some option not working properly. It detects actual selected items by calling jQuery this.$element.val() method which ignore 'selected' property state.