### PR TITLE
data tokens not updating on selectpicker refresh fix

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -608,7 +608,7 @@
         var optionClass = this.className || '',
             inline = htmlEscape(this.style.cssText),
             text = $this.data('content') ? $this.data('content') : $this.html(),
-            tokens = $this.data('tokens') ? $this.data('tokens') : null,
+            tokens = $this.attr('data-tokens') ? $this.attr('data-tokens') : null,
             subtext = typeof $this.data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.data('subtext') + '</small>' : '',
             icon = typeof $this.data('icon') !== 'undefined' ? '<span class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></span> ' : '',
             $parent = $this.parent(),

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -568,7 +568,7 @@
             (inline ? ' style="' + inline + '"' : '') +
             (that.options.liveSearchNormalize ? ' data-normalized-text="' + normalizeToBase(htmlEscape($(text).html())) + '"' : '') +
             (typeof tokens !== 'undefined' || tokens !== null ? ' data-tokens="' + tokens + '"' : '') +
-            ' role="option" aria-label="' + $(text).text().trim() + '">' + text +
+            ' role="option">' + text +
             '<span class="' + that.options.iconBase + ' ' + that.options.tickIcon + ' check-mark"></span>' +
             '</a>';
       };

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -608,7 +608,7 @@
         var optionClass = this.className || '',
             inline = htmlEscape(this.style.cssText),
             text = $this.data('content') ? $this.data('content') : $this.html(),
-            tokens = $this.attr('data-tokens') ? $this.attr('data-tokens') : null,
+            tokens = $this.data('tokens') ? $this.data('tokens') : null,
             subtext = typeof $this.data('subtext') !== 'undefined' ? '<small class="text-muted">' + $this.data('subtext') + '</small>' : '',
             icon = typeof $this.data('icon') !== 'undefined' ? '<span class="' + that.options.iconBase + ' ' + $this.data('icon') + '"></span> ' : '',
             $parent = $this.parent(),

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -568,7 +568,7 @@
             (inline ? ' style="' + inline + '"' : '') +
             (that.options.liveSearchNormalize ? ' data-normalized-text="' + normalizeToBase(htmlEscape($(text).html())) + '"' : '') +
             (typeof tokens !== 'undefined' || tokens !== null ? ' data-tokens="' + tokens + '"' : '') +
-            ' role="option">' + text +
+            ' role="option" aria-label="' + $(text).text().trim() + '">' + text +
             '<span class="' + that.options.iconBase + ' ' + that.options.tickIcon + ' check-mark"></span>' +
             '</a>';
       };


### PR DESCRIPTION
Feeding selectpicker with new data caused data-tokens to remain from the previous one. This was probably caused by a bug in jQuery .data() method. I've replaced this one to .attr() and everything worked like a charm.