### PR TITLE
updates building of title attribute to trim option label white space

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1179,7 +1179,7 @@
 
       //Fixes issue in IE10 occurring when no default option is selected and at least one option is disabled
       //Convert all the values into a comma delimited string
-      var title = !this.multiple ? selectedItemsInTitle[0] : selectedItemsInTitle.join(this.options.multipleSeparator);
+      var title = !this.multiple ? selectedItemsInTitle[0] : selectedItemsInTitle.map($.trim).join(this.options.multipleSeparator);
 
       // add ellipsis
       if (selectedItems.length > 100) title += '...';


### PR DESCRIPTION
This solves an issue where the title attribute is including white space that is inside <option> tags when multiple options are selected.

Given html source like this:

```html
  <select class="selectpicker" multiple>
      <option>
        Apple
      </option>
      <option>
        Orange
      </option>
      <option>Corn</option>
      <option>Carrot</option>
  </select>
```
Select Apple and you end up with: `title="Apple"`.

If however you select Apple and Orange you end up with:
```html
title="Apple
                                        , 
                                            Orange"
```

Only the <option> with inner white space have this issue, selecting Corn or Carrot do not change anything. e.g.

If however you select everything you end up with:
```html
title="Apple
                                        , 
                                            Orange, Corn, Carrot"
```

This was noted previously in #1624, reproduced with v1.12.4 using sample html here.