### PR TITLE
Add regex matching as a live search style

### DIFF
--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -122,7 +122,8 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     <td>string</td>
     <td><code>'contains'</code></td>
     <td>
-      <p>When set to <code>'contains'</code>, searching will reveal options that contain the searched text. For example, searching for pl with return both Ap<b>pl</b>e, <b>Pl</b>um, and <b>Pl</b>antain. When set to <code>'startsWith'</code>, searching for pl will return only <b>Pl</b>um and <b>Pl</b>antain.</p>
+      <p>When set to <code>'contains'</code>, searching will reveal options that contain the searched text. For example, searching for pl will return both Ap<b>pl</b>e, <b>Pl</b>um, and <b>Pl</b>antain. When set to <code>'startsWith'</code>, searching for pl will return only <b>Pl</b>um and <b>Pl</b>antain.</p>
+      <p>When set to <code>'regularExpression'</code>, searching will use use a simple regex match (ignoring whitespace) to determine matches. For example, searching for 'Penn State' will return '<b>Penn</b>sylvania <b>State</b> University (The)'
     </td>
   </tr>
   <tr>

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -193,6 +193,16 @@
     return haystack.startsWith(meta[3].toUpperCase());
   };
 
+  // Case insensitive regex search
+  $.expr.pseudos.iregex = function (obj, index, meta) {
+    var $obj = $(obj).find('a');
+    var haystack = ($obj.data('tokens') || $obj.text()).toString().toUpperCase();
+
+    var q = meta[3].replace(' ', '(.*)').toUpperCase();
+    var re = new RegExp(q);
+    return haystack.match(re);
+  };
+
   // Case and accent insensitive contains search
   $.expr.pseudos.aicontains = function (obj, index, meta) {
     var $obj = $(obj).find('a');
@@ -205,6 +215,16 @@
     var $obj = $(obj).find('a');
     var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toString().toUpperCase();
     return haystack.startsWith(meta[3].toUpperCase());
+  };
+
+  // Case and accent insensitive regex search
+  $.expr.pseudos.airegex = function (obj, index, meta) {
+    var $obj = $(obj).find('a');
+    var haystack = ($obj.data('tokens') || $obj.data('normalizedText') || $obj.text()).toString().toUpperCase();
+
+    var q = meta[3].replace(' ', '(.*)').toUpperCase();
+    var re = new RegExp(q);
+    return haystack.match(re);
   };
 
   /**
@@ -1484,7 +1504,8 @@
     _searchStyle: function () {
       var styles = {
         begins: 'ibegins',
-        startsWith: 'ibegins'
+        startsWith: 'ibegins',
+        regularExpression: 'iregex'
       };
 
       return styles[this.options.liveSearchStyle] || 'icontains';


### PR DESCRIPTION
Adds a new `liveSearchStyle` called `regularExpression` which preforms a match-check using regex and ignoring whitespace. This allow for slightly fuzzier finding such as entering "Penn State", "Pennsylvania State University (The)"

Open to feedback on the the expected value (`regularExpression`) since this is a bit more specific than a generic regex match.

With credit to @robadams