### PR TITLE
Added Option to not close dropdown on select

### DIFF
--- a/docs/docs/options.md
+++ b/docs/docs/options.md
@@ -24,6 +24,14 @@ Options can be passed via data attributes or JavaScript. For data attributes, ap
     </td>
   </tr>
   <tr>
+    <td>closeOnSelect</td>
+    <td>boolean</td>
+    <td><code>true</code></td>
+    <td>
+        <p>When set to <code>false</code>, don't close the dropdown upon select.
+    </td>
+  </tr>
+  <tr>
     <td>container</td>
     <td>string | false</td>
     <td><code>false</code></td>

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -330,6 +330,7 @@
       ];
     },
     selectAllText: 'Select All',
+    closeOnSelect: true,
     deselectAllText: 'Deselect All',
     doneButton: false,
     doneButtonText: 'Close',
@@ -1255,8 +1256,8 @@
             prevIndex = that.$element.prop('selectedIndex'),
             triggerChange = true;
 
-        // Don't close on multi choice menu
-        if (that.multiple && that.options.maxOptions !== 1) {
+        // Don't close on multi choice menu or if closeOnSelect is not set
+        if ((that.multiple && that.options.maxOptions !== 1) || !that.options.closeOnSelect) {
           e.stopPropagation();
         }
 


### PR DESCRIPTION
Add option `closeOnSelect`, which defaults to true.  If set to false, the dropdown will not close when you select an option.