### PR TITLE
Replace 'pull-left' to 'float-left' since its deprecated in BS4

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -500,7 +500,7 @@
       var drop =
           '<div class="btn-group bootstrap-select' + showTick + inputGroup + '">' +
           '<button type="button" class="' + this.options.styleBase + ' dropdown-toggle" data-toggle="dropdown"' + autofocus + ' role="button" aria-labelledby="'+this.$element.attr("aria-labelledby")+'">' +
-          '<span class="filter-option pull-left"></span>&nbsp;' +
+          '<span class="filter-option float-left"></span>&nbsp;' +
           '<span class="bs-caret">' +
           this.options.template.caret +
           '</span>' +


### PR DESCRIPTION
Resolves https://github.com/silviomoreto/bootstrap-select/issues/1895

> Clases .pull-left and .pull-right removed in BS4 since they’re redundant to .float-left and .float-right

https://getbootstrap.com/docs/4.0/migration/#utilities