### PR TITLE
Correctly looking for parent data, using .closest instead of parent()......

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1659,6 +1659,11 @@
           };
 
 
+      // we destroy the modal/popup using the ESC key and then turns out we get
+      // here and the parent doesn't even exist anymore, in this case fail silently.
+      // probably not the best idea, but works.
+      if(!$parent.length) return false;
+	    
       isActive = that.$newElement.hasClass('open');
 
       if (!isActive && (e.keyCode >= 48 && e.keyCode <= 57 || e.keyCode >= 96 && e.keyCode <= 105 || e.keyCode >= 65 && e.keyCode <= 90)) {

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1600,7 +1600,7 @@
 
     keydown: function (e) {
       var $this = $(this),
-          $parent = $this.is('input') ? $this.parent().parent() : $this.parent(),
+          $parent = $this.closest('div.dropdown-menu'),
           $items,
           that = $parent.data('this'),
           index,


### PR DESCRIPTION
Fix buggy workaround to find the wanted parent data, fixed #1085 at least for me.

I'm really not sure if it's a good idea to have this selector ( .dropdown-menu ) hardcoded here because we didn't spend time with anything other than solving this bug on our specific application.

Please fix the selector if needed.

Thanks for the library.