### PR TITLE
make validation feedback work

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -487,6 +487,11 @@
         });
       }
 
+      that.$newElement.siblings().each(function(i, sibling) {
+        var $sibling = $(sibling);
+        if ($sibling.is(".invalid-feedback, .valid-feedback")) $sibling.appendTo(that.$newElement);
+      })
+
       setTimeout(function () {
         that.$element.trigger('loaded.bs.select');
       });


### PR DESCRIPTION
I noticed :valid/:invalid pseudo-class and .is-valid/.is-invalid class are working on bootstrap-select. but .valid-feedback/.invalid-feedback siblings of original select are not working, because the select element is not there any more. so I moved them.