### PR TITLE
Fix group data-max-options=1 error

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2055,7 +2055,7 @@
                   $optgroup.find('option:selected').prop('selected', false);
                   $option.prop('selected', true);
                   var optgroupID = that.selectpicker.current.data[$this.parent().index() + that.selectpicker.view.position0].optID;
-                  that.$menuInner.find('.optgroup-' + optgroupID).removeClass('selected');
+                  that.$menuInner.find('.optgroup-' + optgroupID).removeClass('selected').find('a').removeClass('selected').attr('aria-selected', false);
                   that.setSelected(clickedIndex, true);
                 } else {
                   var maxOptionsText = typeof that.options.maxOptionsText === 'string' ? [that.options.maxOptionsText, that.options.maxOptionsText] : that.options.maxOptionsText,

--- a/tests/bootstrap3.html
+++ b/tests/bootstrap3.html
@@ -122,6 +122,29 @@
   <hr>
   <form class="form-horizontal" role="form">
     <div class="form-group">
+      <label for="basic3" class="col-lg-2 control-label">"Basic" (multiple, group maxOptions=1)</label>
+      <div class="col-lg-10">
+        <select id="basic3" class="selectpicker form-control" multiple>
+          <optgroup label="group1" data-max-options="1">
+            <option>option1</option>
+            <option>option2</option>
+            <option>option3</option>
+            <option>option4</option>
+          </optgroup>
+          <optgroup label="group2" data-max-options="1">
+            <option>option1</option>
+            <option>option2</option>
+            <option>option3</option>
+            <option>option4</option>
+          </optgroup>
+        </select>
+      </div>
+    </div>
+  </form>
+
+  <hr>
+  <form class="form-horizontal" role="form">
+    <div class="form-group">
       <label for="maxOption2" class="col-lg-2 control-label">multiple, show-menu-arrow, maxOptions=2</label>
 
       <div class="col-lg-10">

--- a/tests/bootstrap4.html
+++ b/tests/bootstrap4.html
@@ -123,6 +123,29 @@
   <hr>
   <form role="form">
     <div class="form-group row">
+      <label for="basic3" class="col-lg-2 control-label">"Basic" (multiple, group maxOptions=1)</label>
+      <div class="col-lg-10">
+        <select id="basic3" class="selectpicker form-control" multiple>
+          <optgroup label="group1" data-max-options="1">
+            <option>option1</option>
+            <option>option2</option>
+            <option>option3</option>
+            <option>option4</option>
+          </optgroup>
+          <optgroup label="group2" data-max-options="1">
+            <option>option1</option>
+            <option>option2</option>
+            <option>option3</option>
+            <option>option4</option>
+          </optgroup>
+        </select>
+      </div>
+    </div>
+  </form>
+
+  <hr>
+  <form role="form">
+    <div class="form-group row">
       <label for="maxOption2" class="col-lg-2 control-label">multiple, show-menu-arrow, maxOptions=2</label>
 
       <div class="col-lg-10">


### PR DESCRIPTION
When data-max-options="1" is set on a group, the selected options do not automatically deselect when selecting a different option. Resolves #2027 

I'm not sure if my fix is efficient but it works.