### PR TITLE
Validaton selector

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2071,11 +2071,11 @@
 
       if (this.isDisabled()) {
         this.$newElement.addClass(classNames.DISABLED);
-        this.$button.addClass(classNames.DISABLED).attr('tabindex', -1).attr('aria-disabled', true).prop('disabled', true);
+        this.$button.addClass(classNames.DISABLED).attr('tabindex', -1).attr('aria-disabled', true);
       } else {
         if (this.$button.hasClass(classNames.DISABLED)) {
           this.$newElement.removeClass(classNames.DISABLED);
-          this.$button.removeClass(classNames.DISABLED).attr('aria-disabled', false).prop('disabled', false);
+          this.$button.removeClass(classNames.DISABLED).attr('aria-disabled', false);
         }
 
         if (this.$button.attr('tabindex') == -1 && !this.$element.data('tabindex')) {

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2071,11 +2071,11 @@
 
       if (this.isDisabled()) {
         this.$newElement.addClass(classNames.DISABLED);
-        this.$button.addClass(classNames.DISABLED).attr('tabindex', -1).attr('aria-disabled', true);
+        this.$button.addClass(classNames.DISABLED).attr('tabindex', -1).attr('aria-disabled', true).prop('disabled', true);
       } else {
         if (this.$button.hasClass(classNames.DISABLED)) {
           this.$newElement.removeClass(classNames.DISABLED);
-          this.$button.removeClass(classNames.DISABLED).attr('aria-disabled', false);
+          this.$button.removeClass(classNames.DISABLED).attr('aria-disabled', false).prop('disabled', false);
         }
 
         if (this.$button.attr('tabindex') == -1 && !this.$element.data('tabindex')) {

--- a/less/bootstrap-select.less
+++ b/less/bootstrap-select.less
@@ -73,12 +73,12 @@ select.selectpicker {
   .has-error & .dropdown-toggle,
   .error & .dropdown-toggle,
   &.is-invalid .dropdown-toggle,
-  .was-validated & .selectpicker:invalid + .dropdown-toggle {
+  .was-validated & select:invalid + .dropdown-toggle {
     border-color: @color-red-error;
   }
 
   &.is-valid .dropdown-toggle,
-  .was-validated & .selectpicker:valid + .dropdown-toggle {
+  .was-validated & select:valid + .dropdown-toggle {
     border-color: @color-green-success;
   }
 

--- a/sass/bootstrap-select.scss
+++ b/sass/bootstrap-select.scss
@@ -91,12 +91,12 @@ select.selectpicker {
   .has-error & .dropdown-toggle,
   .error & .dropdown-toggle,
   &.is-invalid .dropdown-toggle,
-  .was-validated & .selectpicker:invalid + .dropdown-toggle {
+  .was-validated & select:invalid + .dropdown-toggle {
     border-color: $color-red-error;
   }
 
   &.is-valid .dropdown-toggle,
-  .was-validated & .selectpicker:valid + .dropdown-toggle {
+  .was-validated & select:valid + .dropdown-toggle {
     border-color: $color-green-success;
   }
 


### PR DESCRIPTION
The .selectpicker class may not exist on the select element if it's initialized directly via javascript, which breaks the validation styling.  Changing the selectors to look for the select element directly fixes it.