### PR TITLE
change search input type from "text" to "search"

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1021,7 +1021,7 @@
       if (this.options.liveSearch) {
         searchbox =
           '<div class="bs-searchbox">' +
-            '<input type="text" class="form-control" autocomplete="off"' +
+            '<input type="search" class="form-control" autocomplete="off"' +
               (
                 this.options.liveSearchPlaceholder === null ? ''
                 :


### PR DESCRIPTION
modern browsers add an X icon to quickly clear the value of a `search` type input when it contains a value.

if they aren't using a modern browser it falls back to a standard `text` type anyways.

this makes users happy.