### PR TITLE
fix focus in dropdowns on keyboard navigation

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2752,7 +2752,7 @@
         if (that.options.liveSearch) {
           that.$searchbox.trigger('focus');
         } else {
-          $this.trigger('focus');
+            liActive.children[0].focus();
         }
       } else if (
         (!$this.is('input') && !REGEXP_TAB_OR_ESCAPE.test(e.which)) ||


### PR DESCRIPTION
At the moment screenreaders don´t work on the dropdowns, because the focus is not set correctly.