### PR TITLE
Added new CDN - PageCDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Several quick start options are available:
 - Install with [Composer](https://getcomposer.org): `composer require snapappointments/bootstrap-select`
 - Install with [NuGet](https://www.nuget.org/packages/bootstrap-select): `Install-Package bootstrap-select`
 - Install with [Bower](https://bower.io): `bower install bootstrap-select`
-- Install via CDN ([PageCDN](https://pagecdn.com/lib/bootstrap-select) or [cdnjs](https://cdnjs.com/libraries/bootstrap-select) or [jsDelivr](https://www.jsdelivr.com/package/npm/bootstrap-select)):
+- Install via CDN ([cdnjs](https://cdnjs.com/libraries/bootstrap-select), [jsDelivr](https://www.jsdelivr.com/package/npm/bootstrap-select) or [PageCDN](https://pagecdn.com/lib/bootstrap-select)):
 
 ```html
 <!-- Latest compiled and minified CSS -->

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Several quick start options are available:
 - Install with [Composer](https://getcomposer.org): `composer require snapappointments/bootstrap-select`
 - Install with [NuGet](https://www.nuget.org/packages/bootstrap-select): `Install-Package bootstrap-select`
 - Install with [Bower](https://bower.io): `bower install bootstrap-select`
-- Install via CDN ([cdnjs](https://cdnjs.com/libraries/bootstrap-select) or [jsDelivr](https://www.jsdelivr.com/package/npm/bootstrap-select)):
+- Install via CDN ([PageCDN](https://pagecdn.com/lib/bootstrap-select) or [cdnjs](https://cdnjs.com/libraries/bootstrap-select) or [jsDelivr](https://www.jsdelivr.com/package/npm/bootstrap-select)):
 
 ```html
 <!-- Latest compiled and minified CSS -->

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -15,7 +15,7 @@ Several quick start options are available:
 - Install with [Composer](https://getcomposer.org): `composer require snapappointments/bootstrap-select`
 - Install with [NuGet](https://www.nuget.org/packages/bootstrap-select): `Install-Package bootstrap-select`
 - Install with [Bower](https://bower.io): `bower install bootstrap-select`
-- Install via CDN ([PageCDN](https://pagecdn.com/lib/bootstrap-select) or [cdnjs](https://cdnjs.com/libraries/bootstrap-select) or [jsDelivr](https://www.jsdelivr.com/package/npm/bootstrap-select)):
+- Install via CDN ([cdnjs](https://cdnjs.com/libraries/bootstrap-select), [jsDelivr](https://www.jsdelivr.com/package/npm/bootstrap-select) or [PageCDN](https://pagecdn.com/lib/bootstrap-select)):
 
 ```html
 <!-- Latest compiled and minified CSS -->

--- a/docs/docs/index.md
+++ b/docs/docs/index.md
@@ -15,7 +15,7 @@ Several quick start options are available:
 - Install with [Composer](https://getcomposer.org): `composer require snapappointments/bootstrap-select`
 - Install with [NuGet](https://www.nuget.org/packages/bootstrap-select): `Install-Package bootstrap-select`
 - Install with [Bower](https://bower.io): `bower install bootstrap-select`
-- Install via CDN ([cdnjs](https://cdnjs.com/libraries/bootstrap-select) or [jsDelivr](https://www.jsdelivr.com/package/npm/bootstrap-select)):
+- Install via CDN ([PageCDN](https://pagecdn.com/lib/bootstrap-select) or [cdnjs](https://cdnjs.com/libraries/bootstrap-select) or [jsDelivr](https://www.jsdelivr.com/package/npm/bootstrap-select)):
 
 ```html
 <!-- Latest compiled and minified CSS -->


### PR DESCRIPTION
PageCDN uses brotli-11 compression that reduces bootstrap-select size by few more KBs compared to other CDNs. In addition, immutable caching is enabled by default to optimize content delivery aggressively. This will make PageCDN a valuable addition to the documentation.

Thanks.