### PR TITLE
Removing source map reference comment on development source file.

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function (grunt) {
     concat: {
       options: {
         stripBanners: true,
-        sourceMap: true
+        sourceMap: false
       },
       main: {
         src: 'js/<%= pkg.name %>.js',
@@ -83,8 +83,7 @@ module.exports = function (grunt) {
         dest: 'dist/js/<%= pkg.name %>.min.js',
         options: {
           sourceMap: true,
-          sourceMapIncludeSources: true,
-          sourceMapIn: 'dist/js/<%= pkg.name %>.js.map'
+          sourceMapIncludeSources: true
         }
       },
       i18n: {


### PR DESCRIPTION
This fix is because there is an issue in safari, when using the source file instead of using the minified version. Usually the only file that requires the sourcemap is the minified one, but since version 1.13.6 you are adding the sourcemap comment to the bootstrap-select.js file. That causes a 404 because of a missing source map file. I use only the source file not the sourcemap in prod. Hope you'll understand the issue.

Thanks in advance.