### PR TITLE
Start counting selected options at 1

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1673,12 +1673,12 @@
       if (this.options.selectedTextFormat === 'static') {
         titleFragment = generateOption.text.call(this, { text: this.options.title }, true);
       } else {
-        showCount = this.multiple && this.options.selectedTextFormat.indexOf('count') !== -1 && selectedCount > 1;
+        showCount = this.multiple && this.options.selectedTextFormat.indexOf('count') !== -1 && selectedCount > 0;
 
         // determine if the number of selected options will be shown (showCount === true)
         if (showCount) {
           countMax = this.options.selectedTextFormat.split('>');
-          showCount = (countMax.length > 1 && selectedCount > countMax[1]) || (countMax.length === 1 && selectedCount >= 2);
+          showCount = (countMax.length > 1 && selectedCount > countMax[1]) || (countMax.length === 1 && selectedCount > 0);
         }
 
         // only loop through all selected options if the count won't be shown

--- a/tests/bootstrap3.html
+++ b/tests/bootstrap3.html
@@ -309,6 +309,20 @@
       </select>
     </div>
   </form>
+  <hr>
+  <form>
+    <div class="form-group row">
+      <label class="col-lg-2 control-label" for="lunchBegins">Display count selected</label>
+      <div class="col-lg-10">
+        <select id="licorice" class="selectpicker" multiple="multiple">
+          <option>Allsorts</option>
+          <option>Anise gumdrops</option>
+          <option>Australian</option>
+          <option>Salmiak</option>
+          <option>Turkish Pepper</option>
+        </select>
+      </div>
+  </form>
 </div>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.3/jquery.min.js"></script>
@@ -351,6 +365,13 @@ $('#special2').on('click', function () {
 $('#basic2').selectpicker({
   liveSearch: true,
   maxOptions: 1
+});
+
+$('#licorice').selectpicker({
+  countSelectedText: function(count){ 
+    return "Licorices (" + count + ")";
+  },
+  selectedTextFormat: 'count'
 });
 </script>
 </body>

--- a/tests/bootstrap4.html
+++ b/tests/bootstrap4.html
@@ -312,6 +312,20 @@
       </div>
     </div>
   </form>
+  <hr>
+  <form>
+    <div class="form-group row">
+      <label class="col-lg-2 control-label" for="lunchBegins">Display count selected</label>
+      <div class="col-lg-10">
+        <select id="licorice" class="selectpicker" multiple="multiple">
+          <option>Allsorts</option>
+          <option>Anise gumdrops</option>
+          <option>Australian</option>
+          <option>Salmiak</option>
+          <option>Turkish Pepper</option>
+        </select>
+      </div>
+  </form>
 </div>
 
 <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.2.1/jquery.min.js"></script>
@@ -353,6 +367,13 @@ $('#special2').on('click', function () {
 $('#basic2').selectpicker({
   liveSearch: true,
   maxOptions: 1
+});
+
+$('#licorice').selectpicker({
+  countSelectedText: function(count){ 
+    return "Licorices (" + count + ")";
+  },
+  selectedTextFormat: 'count'
 });
 </script>
 </body>


### PR DESCRIPTION
This PR addresses issue #2367 : currently if set `selectedTextFormat` to `count` or `count > 0`, when the user selects one option, the text displayed can be determined using `countSelectedText` unless the user happens to select only one option, and then that one option is displayed. That can look very inconsistent, especially if the `<select>` has a limited width and the selected option is longer.

The change here just fixes the `selectedCount` threshold at which the `countSelectedText` function comes into play (from 2 to 1). Test cases are included. I don't think the documentation needs to be updated, since that's already accurate:

> [countSelectedText] Sets the format for the text displayed when selectedTextFormat is count or count > #. {0} is the selected amount. {1} is total available for selection.

> [selectedTextFormat] 'count' displays the total number of selected options. 'count > x' behaves like 'values' until the number of selected options is greater than x; after that, it behaves like 'count'.

This _could_ be considered a breaking change to anyone who's expecting/relying on the previous behavior, but it's easy to get back the previous behavior by setting `selectedTextFormat` to `count > 1`