### PR TITLE
Delete spaces before applying a search

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -416,7 +416,7 @@
         }
 
         if (normalize) string = normalizeToBase(string);
-        string = string.toUpperCase();
+        string = string.toUpperCase().trim();
 
         if (method === 'contains') {
           searchSuccess = string.indexOf(searchString) >= 0;


### PR DESCRIPTION
In case that the shown list contains spaces before the actual string, the startwith search will not work
This is a real case that I found when using this library