### PR TITLE
chore: [v1.13.0-dev-search-icon] 

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -893,7 +893,8 @@
     tickIcon: classNames.TICKICON,
     showTick: false,
     template: {
-      caret: '<span class="caret"></span>'
+      caret: '<span class="caret"></span>',
+      searchIcon: ''
     },
     maxOptions: false,
     mobile: false,
@@ -1060,6 +1061,7 @@
       if (this.options.liveSearch) {
         searchbox =
           '<div class="bs-searchbox">' +
+          this.options.template.searchIcon
             '<input type="search" class="form-control" autocomplete="off"' +
               (
                 this.options.liveSearchPlaceholder === null ? ''


### PR DESCRIPTION
allow search icon via a template injection.

sample code

```
               <select className="selectpicker " data-live-search="true">
                  <option data-value="Hot Dog, Fries and a Soda" data-tokens="ketchup mustard">
                    Hot Dog, Fries and a Soda
                  </option>
                  <option data-value="Burger, Shake and a Smile" data-tokens="mustard">
                    Burger, Shake and a Smile
                  </option>
                  <option data-value="Sugar, Spice and all things nice" data-tokens="frosting">
                    Sugar, Spice and all things nice
                  </option>
                </select>
```

```
  $(function () {
    $("select.selectpicker").selectpicker({
      template:{
        searchIcon: '<span class="search"></span>'
      }
    });
  });
```

![DeepinScreenshot_select-area_20200525181943](https://user-images.githubusercontent.com/596701/82829776-5f655600-9eb4-11ea-9b38-ac5eced656b6.png)
