### PR TITLE
Fixes two `TypeError` exceptions when up/down arrow pressed

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2913,7 +2913,7 @@
 
         liActive = that.selectpicker.current.elements[liActiveIndex];
 
-        that.activeIndex = that.selectpicker.current.data[liActiveIndex].index;
+        that.activeIndex = (that.selectpicker.current.data[liActiveIndex] || {}).index;
 
         that.focusItem(liActive);
 

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2885,9 +2885,13 @@
             liActiveIndex = that.selectpicker.current.elements.length - 1;
           } else {
             activeLi = that.selectpicker.current.data[liActiveIndex];
-            offset = activeLi.position - activeLi.height;
 
-            updateScroll = offset < scrollTop;
+            // could be undefined if no results exist
+            if (activeLi) {
+              offset = activeLi.position - activeLi.height;
+
+              updateScroll = offset < scrollTop;
+            }
           }
         } else if (e.which === keyCodes.ARROW_DOWN || downOnTab) { // down
           // scroll to top and highlight first option
@@ -2897,9 +2901,13 @@
             liActiveIndex = that.selectpicker.view.firstHighlightIndex;
           } else {
             activeLi = that.selectpicker.current.data[liActiveIndex];
-            offset = activeLi.position - that.sizeInfo.menuInnerHeight;
 
-            updateScroll = offset > scrollTop;
+            // could be undefined if no results exist
+            if (activeLi) {
+              offset = activeLi.position - that.sizeInfo.menuInnerHeight;
+
+              updateScroll = offset > scrollTop;
+            }
           }
         }
 


### PR DESCRIPTION
It looks like issue #2035 is happening again in the latest v1.13 release. When using live search, if a user enters a query that has no matches and then presses the up or down arrows, two different `TypeError` exceptions can occur. This PR fixes both exceptions.

For reference, here are the steps to reproduce the issue, copied from the original issue:

Browser: All
OS environment: All

Steps to reproduce:

1. Open selctbox and type "xxx" to search
1. No results matched "xxx" will appear
1. Press DOWN key
1. Error is thrown