### PR TITLE
fix(close): Header example with button close

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1135,7 +1135,7 @@
       if (this.options.header) {
         header =
           '<div class="' + classNames.POPOVERHEADER + '">' +
-            '<button type="button" class="close" aria-hidden="true">&times;</button>' +
+            '<button type="button" class="btn-close close float-end" aria-hidden="true"></button>' +
               this.options.header +
           '</div>';
       }


### PR DESCRIPTION
BS5 changed the close button class to btn-close: https://getbootstrap.com/docs/5.0/components/close-button/
Added class with float utility