### PR TITLE
Fix long text option overflow

### DIFF
--- a/sass/bootstrap-select.scss
+++ b/sass/bootstrap-select.scss
@@ -315,6 +315,7 @@ select.selectpicker {
   // The selectpicker dropdown
   .dropdown-menu {
     min-width: 100%;
+    max-width: 100%;
     @include box-sizing(border-box);
 
     > .inner:focus {


### PR DESCRIPTION
Add max-width 100% in .dropdown-menu class to prevent text overflow.