### PR TITLE
max-height/offsetHeight Calculation Issue, Fixes #2581

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2175,8 +2175,8 @@
       this.sizeInfo.scrollBarWidth = scrollBarWidth;
       this.sizeInfo.selectHeight = this.$newElement[0].offsetHeight;
 
-      if (newElementAnchorDisplay !== undefined && newElementAnchorDisplay !== "") newElementAnchor.css('display', newElementAnchorDisplay);
-      if (newElementAnchorVisibility !== undefined && newElementAnchorVisibility !== "") newElementAnchor.css('visibility', newElementAnchorVisibility);
+      if (newElementAnchorDisplay !== undefined && newElementAnchorDisplay !== '') newElementAnchor.css('display', newElementAnchorDisplay);
+      if (newElementAnchorVisibility !== undefined && newElementAnchorVisibility !== '') newElementAnchor.css('visibility', newElementAnchorVisibility);
 
       this.setPositionData();
     },

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2113,6 +2113,15 @@
       if (doneButton) menu.appendChild(doneButton);
       newElement.appendChild(menu);
 
+      var $li = $(li);
+      $("a", $li).show(); // always make sure first item is shown, otherwise offsetHeight = 0
+      var $a = $("a", $li);
+      var itemIsBlank = $a.text() == "";
+      if (itemIsBlank) {
+        // If blank, set text to non-breaking space otherwise offsetHeight = 8 (or some portion of full height)
+        $a.text = "&nbsp;";
+      }
+
       document.body.appendChild(newElement);
 
       var liHeight = li.offsetHeight,

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2115,7 +2115,7 @@
 
       var newElementAnchor = $('a', $(li));
       newElementAnchor.show(); // always make sure first item is shown, otherwise offsetHeight = 0
-      if (newElementAnchor.text() == '') {
+      if (newElementAnchor.text() === '') {
         // If blank, set text to non-breaking space otherwise offsetHeight = 8 (or some portion of full height)
         newElementAnchor.text = '&nbsp;';
       }

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2115,8 +2115,8 @@
 
       var newElementAnchor = $('a', $(li));
       // Get 'visible' css items to restore after calculation is done
-      var newElementAnchorDisplay = newElementAnchor.css("display");
-      var newElementAnchorVisibility = newElementAnchor.css("visibility");
+      var newElementAnchorDisplay = newElementAnchor.css('display');
+      var newElementAnchorVisibility = newElementAnchor.css('visibility');
       newElementAnchor.show(); // always make sure first item is shown, otherwise offsetHeight = 0
       if (newElementAnchor.text() === '') {
         // If blank, set text to non-breaking space otherwise offsetHeight = 8 (or some portion of full height)
@@ -2175,8 +2175,8 @@
       this.sizeInfo.scrollBarWidth = scrollBarWidth;
       this.sizeInfo.selectHeight = this.$newElement[0].offsetHeight;
 
-      if (newElementAnchorDisplay !== undefined && newElementAnchorDisplay !== "") newElementAnchor.css("display", newElementAnchorDisplay);
-      if (newElementAnchorVisibility !== undefined && newElementAnchorVisibility !== "") newElementAnchor.css("visibility", newElementAnchorVisibility);
+      if (newElementAnchorDisplay !== undefined && newElementAnchorDisplay !== "") newElementAnchor.css('display', newElementAnchorDisplay);
+      if (newElementAnchorVisibility !== undefined && newElementAnchorVisibility !== "") newElementAnchor.css('visibility', newElementAnchorVisibility);
 
       this.setPositionData();
     },

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2114,6 +2114,9 @@
       newElement.appendChild(menu);
 
       var newElementAnchor = $('a', $(li));
+      // Get 'visible' css items to restore after calculation is done
+      var newElementAnchorDisplay = newElementAnchor.css("display");
+      var newElementAnchorVisibility = newElementAnchor.css("visibility");
       newElementAnchor.show(); // always make sure first item is shown, otherwise offsetHeight = 0
       if (newElementAnchor.text() === '') {
         // If blank, set text to non-breaking space otherwise offsetHeight = 8 (or some portion of full height)
@@ -2171,6 +2174,9 @@
       this.sizeInfo.totalMenuWidth = this.sizeInfo.menuWidth;
       this.sizeInfo.scrollBarWidth = scrollBarWidth;
       this.sizeInfo.selectHeight = this.$newElement[0].offsetHeight;
+
+      if (newElementAnchorDisplay !== undefined && newElementAnchorDisplay !== "") newElementAnchor.css("display", newElementAnchorDisplay);
+      if (newElementAnchorVisibility !== undefined && newElementAnchorVisibility !== "") newElementAnchor.css("visibility", newElementAnchorVisibility);
 
       this.setPositionData();
     },

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2113,13 +2113,11 @@
       if (doneButton) menu.appendChild(doneButton);
       newElement.appendChild(menu);
 
-      var $li = $(li);
-      $("a", $li).show(); // always make sure first item is shown, otherwise offsetHeight = 0
-      var $a = $("a", $li);
-      var itemIsBlank = $a.text() == "";
-      if (itemIsBlank) {
+      var newElementAnchor = $('a', $(li));
+      newElementAnchor.show(); // always make sure first item is shown, otherwise offsetHeight = 0
+      if (newElementAnchor.text() == '') {
         // If blank, set text to non-breaking space otherwise offsetHeight = 8 (or some portion of full height)
-        $a.text = "&nbsp;";
+        newElementAnchor.text = '&nbsp;';
       }
 
       document.body.appendChild(newElement);


### PR DESCRIPTION
Fixes #2581

If the number of items in the dropdown > `this.options.size`, then the following line runs:

`menuHeight = liHeight * this.options.size + divLength * divHeight + menuPadding.vert;`

However, `liHeight` is calculated wrong if the first item is hidden or if first item has text of `''`.

Before adding the temporary `newElement` to the `body` to calculate height, I always show the first item (I didn't check to see if hidden), and if first items text = `''`, I set it to `&nbsp;` (probably wouldn't need a check here either).