### PR TITLE
Disabled btn-light

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -3291,7 +3291,7 @@
 
       classNames.DIVIDER = 'dropdown-divider';
       classNames.SHOW = 'show';
-      classNames.BUTTONCLASS = 'btn-light';
+      /*classNames.BUTTONCLASS = 'btn-light';*/
       classNames.POPOVERHEADER = 'popover-header';
       classNames.ICONBASE = '';
       classNames.TICKICON = 'bs-ok-default';


### PR DESCRIPTION
Better compatibility with bootstrap-dark. With disabled btn-light look much better in bootstrap-dark mode. Even in light mode look still very good.

Make sure to target the `dev` branch!
