### PR TITLE
Close drop down when selecting item with enter key

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -3175,8 +3175,10 @@
             $(document).data('spaceSelect', true);
           }
         }
-        // hide dropdown menu
-        that.dropdown.hide();
+        if (e.which === keyCodes.ENTER) {
+          // hide dropdown menu
+          that.dropdown.hide();
+        }
       }
     },
 

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -3175,6 +3175,8 @@
             $(document).data('spaceSelect', true);
           }
         }
+        // hide dropdown menu
+        that.dropdown.hide();
       }
     },
 


### PR DESCRIPTION
This ensures that the drop down closes after choosing an item by pressing the enter key.

Fixes [#2697](https://github.com/snapappointments/bootstrap-select/issues/2697)