### PR TITLE
max-height/offsetHeight Calculation Issue, Fixes #2581

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2118,6 +2118,16 @@
       if (doneButton) menu.appendChild(doneButton);
       newElement.appendChild(menu);
 
+      var newElementAnchor = $('a', $(li));
+      // Get 'visible' css items to restore after calculation is done
+      var newElementAnchorDisplay = newElementAnchor.css('display');
+      var newElementAnchorVisibility = newElementAnchor.css('visibility');
+      newElementAnchor.show(); // always make sure first item is shown, otherwise offsetHeight = 0
+      if (newElementAnchor.text() === '') {
+        // If blank, set text to non-breaking space otherwise offsetHeight = 8 (or some portion of full height)
+        newElementAnchor.text = '&nbsp;';
+      }
+
       document.body.appendChild(newElement);
 
       var liHeight = li.offsetHeight,
@@ -2169,6 +2179,9 @@
       this.sizeInfo.totalMenuWidth = this.sizeInfo.menuWidth;
       this.sizeInfo.scrollBarWidth = scrollBarWidth;
       this.sizeInfo.selectHeight = this.$newElement[0].offsetHeight;
+
+      if (newElementAnchorDisplay !== undefined && newElementAnchorDisplay !== '') newElementAnchor.css('display', newElementAnchorDisplay);
+      if (newElementAnchorVisibility !== undefined && newElementAnchorVisibility !== '') newElementAnchor.css('visibility', newElementAnchorVisibility);
 
       this.setPositionData();
     },


### PR DESCRIPTION
Fixes #2581

If the number of items in the dropdown > `this.options.size`, then the following line runs:

`menuHeight = liHeight * this.options.size + divLength * divHeight + menuPadding.vert;`

However, `liHeight` is calculated wrong if the first item is hidden or if first item has text of `''`.

Before adding the temporary `newElement` to the `body` to calculate height, I always show the first item (I didn't check to see if hidden), and if first items text = `''`, I set it to `&nbsp;` (probably wouldn't need a check here either).

Have created a new branch/commit for previous attempt at PR.  Was able to run grunt lint successfully.

[Original PR with some commentary about lint issues](https://github.com/snapappointments/bootstrap-select/pull/2653)