### PR TITLE
ARIA Accessibility Fixes

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1205,7 +1205,7 @@
             (this.options.display === 'static' ? 'data-display="static"' : '') +
             Selector.DATA_TOGGLE +
             autofocus +
-            ' role="combobox" aria-owns="' +
+            ' aria-owns="' +
             this.selectId +
             '" aria-haspopup="listbox" aria-expanded="false">' +
             '<div class="filter-option">' +

--- a/sass/variables.scss
+++ b/sass/variables.scss
@@ -7,7 +7,7 @@ $width-default: 220px !default; // 3 960px-grid columns
 $zindex-select-dropdown: 1060 !default; // must be higher than a modal background (1050)
 
 //** Placeholder text color
-$input-color-placeholder: #999 !default;
+$input-color-placeholder: #666 !default;
 $input-alt-color-placeholder: rgba(255, 255, 255, 0.5) !default;
 
 $input-padding-y-sm: .25rem !default;


### PR DESCRIPTION
Using the Deque Axe DevTools (https://www.deque.com/axe/devtools/) we've found some ARIA accessibility bugs and would like to have them fixed. If you're not familiar with Axe, it is a great tool that also has free developer browser extensions for testing. Below are the details.

Issue https://github.com/snapappointments/bootstrap-select/pull/1: ARIA role combobox not allowed on a button element
Issue https://github.com/snapappointments/bootstrap-select/pull/2: Insufficient color contrast on the placeholder text

Some background on Issue https://github.com/snapappointments/bootstrap-select/pull/1:
The issue is that the button [role](https://www.w3.org/TR/2014/REC-html5-20141028/infrastructure.html#attr-aria-role) set by Bootstrap Select is ‘combobox’, however this is not a valid ARIA role for a button and thus fails the Axe testing. A button element already has native semantics through HTML/Browsers.

In the majority of cases setting an ARIA role and/or aria-* attribute that matches the default implicit ARIA semantics is unnecessary and not recommended as these properties are already set by the browser.

Many HTML5 elements come with default implicit ARIA semantics, and explicitly setting these default values is "unnecessary and not recommended".

Looking at the button element, you can see that it has the button role by default. So, setting role="button" is "not recommended. As the W3C documentation says : button element has default role="button".

Allowed ARIA role attribute values:
button (default - do not set), link, menuitem, menuitemcheckbox, menuitemradio or radio.

Role of combobox is not a valid role for a button as defined above.

I've also attached the Axe test failures for your reference.
<img width="773" alt="button-invalid-aria-role" src="https://user-images.githubusercontent.com/7266812/163650066-8d83fe3c-f716-4dc4-89e4-cb5c5d2c02db.png">
<img width="775" alt="placeholder-aria-contrast-error" src="https://user-images.githubusercontent.com/7266812/163650079-35e03864-200c-4756-a594-23ed842f7d4e.png">
