### PR TITLE
Fix "bootstrap is not defined" error

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -616,8 +616,7 @@
     ARROW_DOWN: 40 // KeyboardEvent.which value for down arrow key
   };
 
-  // eslint-disable-next-line no-undef
-  var Dropdown = window.Dropdown || bootstrap.Dropdown;
+  var Dropdown = window.Dropdown || window.bootstrap && window.bootstrap.Dropdown;
 
   function getVersion () {
     var version;


### PR DESCRIPTION
This line throws for Bootstrap < 5 because it's trying to access a global variable that doesn't exist. Use `window.bootstrap` instead for backwards compatibility.

Fixes #2720
