### PR TITLE
Fix dropdown position when use data-size attribute

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2250,11 +2250,8 @@
         // This is useful for smaller menus, where there might be plenty of room
         // below the button without setting dropup, but we can't know
         // the exact height of the menu until createView is called later
-        if (this.options.size !== 'auto') {
-          estimate = liHeight * this.options.size + menuPadding.vert;
-        } else {
-          estimate = liHeight * this.selectpicker.current.data.length + menuPadding.vert;
-        }
+        var dropDownLength = this.options.size !== 'auto' ? this.options.size : this.selectpicker.current.data.length;
+        estimate = liHeight * dropDownLength + menuPadding.vert;
 
         isDropup = this.sizeInfo.selectOffsetTop - this.sizeInfo.selectOffsetBot > this.sizeInfo.menuExtras.vert && estimate + this.sizeInfo.menuExtras.vert + 50 > this.sizeInfo.selectOffsetBot;
 

--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2250,7 +2250,11 @@
         // This is useful for smaller menus, where there might be plenty of room
         // below the button without setting dropup, but we can't know
         // the exact height of the menu until createView is called later
-        estimate = liHeight * this.selectpicker.current.data.length + menuPadding.vert;
+        if (this.options.size !== 'auto') {
+          estimate = liHeight * this.options.size + menuPadding.vert;
+        } else {
+          estimate = liHeight * this.selectpicker.current.data.length + menuPadding.vert;
+        }
 
         isDropup = this.sizeInfo.selectOffsetTop - this.sizeInfo.selectOffsetBot > this.sizeInfo.menuExtras.vert && estimate + this.sizeInfo.menuExtras.vert + 50 > this.sizeInfo.selectOffsetBot;
 


### PR DESCRIPTION
When select has a lot of option (in my case 100+) I wanted to limit it to display only the 6 options with scroll. I use attribute data-size set to 6. But when i click to open select, isDropup flag is set to true, and option show above a select but is enough space to display options below button.

Fix #2766 