### PR TITLE
Added files packing rules for 'contentFiles\' for .NET Core and .NET 5.0+ Support

### DIFF
--- a/nuget/bootstrap-select.nuspec
+++ b/nuget/bootstrap-select.nuspec
@@ -20,5 +20,9 @@
         <file src="dist\js\bootstrap-select*.*" target="content\Scripts" />
         <file src="dist\js\i18n\*.*" target="content\Scripts\i18n" />
         <file src="dist\css\*.*" target="content\Content" />
+
+        <file src="dist\js\bootstrap-select*.*" target="contentFiles\any\any\wwwroot\js" />
+        <file src="dist\js\i18n\*.*" target="contentFiles\any\any\wwwroot\js\i18n" />
+        <file src="dist\css\*.*" target="contentFiles\any\any\wwwroot\css" />
     </files>
 </package>


### PR DESCRIPTION
Hi bootstrap-select team:

One of my coworkers wanted a have a nice bootstrap themed override for the default browser handling of \<select\> dropboxes, and we selected your project, however we've recently transitioned to .NET 5.0 and 6.0 and found that your project is one of the ones that only target .NET 4.x and older's style. With the new project layout we'd appreciate the automagic copy to /wwwroot/*/ like how (twitter) bootstrap actual does it, so I reverse engineered the [relevant lines](https://github.com/twbs/bootstrap/blob/a685b9648bf14c853b9a417c7c68f95d93e1aabc/nuget/bootstrap.nuspec#L32) from their bootstrap's nuspec file as seen on github and added it to bootstrap-select's. 

.NET Core and 5.0+ automatically copy over content files to, as opposed to earlier which copies to 'content\'

https://docs.microsoft.com/en-us/nuget/reference/nuspec#including-content-files

I haven't tried running nuget pack on my branch and importing it into one of our projects yet, but I plan to do so sometime next week, but I wanted to get the PR in earlier, in case someone is able to get it tested and confirmed good before I can.

Make sure to target the `dev` branch! 👍
