### PR TITLE
Fix virtualScroll issue #2524

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -1347,7 +1347,9 @@
           }
         }
 
-        if (currentChunk === undefined) currentChunk = 0;
+        //If the current chunk can't be found based on the scroll position
+        // in the loop above, we need to assume that we are in the final chunk, not the first chunk
+        if (currentChunk === undefined) currentChunk = chunkCount-1;
 
         prevPositions = [that.selectpicker.view.position0, that.selectpicker.view.position1];
 


### PR DESCRIPTION
Scrolling to the bottom of a bootstrap-select with virtualScroll enabled (where the number of elements exceeded the configured value) would not show any li's. (#2524)

Make sure to target the `dev` branch!
