### PR TITLE
fix refresh action

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -3393,6 +3393,8 @@
       var config = $.extend({}, this.options, getAttributesObject(this.$element), this.$element.data()); // in this order on refresh, as user may change attributes on select, and options object is not passed on refresh
       this.options = config;
 
+      this.selectpicker.main.data = [];
+
       if (this.options.source.data) {
         this.render();
         this.buildList();


### PR DESCRIPTION
The refresh function is broken.

It duplicates the lines in the dropdown as well as the button title text.

How to reproduce :

- checkout main or dev branch.
- open tests/bootstrap5.html
- select a value with a selectpicker
- trigger the refresh function on the modified select (using browser console)

As a result :

- button title is duplicated
- drowdown elements are duplicated