### PR TITLE
fix val method

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -3063,7 +3063,7 @@
 
         if (!Array.isArray(value)) value = [ value ];
 
-        value.map(String);
+        value = value.map(String);
 
         for (var i = 0; i < selectedOptions.length; i++) {
           var item = selectedOptions[i];


### PR DESCRIPTION
The val function does not work with integer values.

How to reproduce :

- checkout main or dev branch.
- open tests/bootstrap5.html
- open browser console
- run following js in console :
```js
$('#number').selectpicker('val', 1); // Does not work
$('#number').selectpicker('val', "1"); // Works
```

for a given 

```
<option value="1">Option 1</option>
```

both `1` (integer) and `"1"` (string) values should work.