### PR TITLE
Fixes: Opening dropdown does not scroll to selected option first time…

### DIFF
--- a/js/bootstrap-select.js
+++ b/js/bootstrap-select.js
@@ -2703,6 +2703,8 @@
       }
 
       this.$element.on('shown' + EVENT_KEY, function () {
+        that.createView(false, true);
+        
         if (that.$menuInner[0].scrollTop !== that.selectpicker.view.scrollTop) {
           that.$menuInner[0].scrollTop = that.selectpicker.view.scrollTop;
         }


### PR DESCRIPTION
…, but does second time

Fix for issue:

The dropdown renders with an option selected. But when I click to open the dropdown, it does not show the selected option, but instead the list is at the top. However, close the dropdown and click to open it again and this time it will be scrolled to the selected option. #2838 

https://jsfiddle.net/cvnjmx20/
