### PR TITLE
More appropriate messages for Croatian language

### DIFF
--- a/js/i18n/defaults-hr_HR.js
+++ b/js/i18n/defaults-hr_HR.js
@@ -6,14 +6,12 @@
 (function ($) {
   $.fn.selectpicker.defaults = {
     noneSelectedText: 'Odaberite stavku',
-    noneResultsText: 'Nema rezultata pretrage {0}',
-    countSelectedText: function (numSelected, numTotal) {
-      return (numSelected == 1) ? '{0} stavka selektirana' : '{0} stavke selektirane';
-    },
+    noneResultsText: 'Nema rezultata za {0}',
+    countSelectedText:  'Selektirano stavaka: {0}',
     maxOptionsText: function (numAll, numGroup) {
       return [
-        (numAll == 1) ? 'Limit je postignut ({n} stvar maximalno)' : 'Limit je postignut ({n} stavke maksimalno)',
-        (numGroup == 1) ? 'Grupni limit je postignut ({n} stvar maksimalno)' : 'Grupni limit je postignut ({n} stavke maksimalno)'
+        'Limit postignut (maksimalno {n})',
+        'Grupni limit postignut (maksimalno {n})'
       ];
     },
     selectAllText: 'Selektiraj sve',


### PR DESCRIPTION
More appropriate messages for Croatian language.
Main problem were numbers on selected items and limits that were not appropriate in some contexts.

